### PR TITLE
Ajout "Sélection Aléatoire" des chansons d'une constitution

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -77,6 +77,7 @@ import { AuthService } from './services/auth.service';
 import { ResultsFavoritesComponent } from './components/constitution-page/results/results-favorites/results-favorites.component';
 import { PieComponent } from './components/template/pie/pie.component';
 import { GradeElectoralComponent } from './components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component';
+import { RandomSongComponent } from './components/constitution-page/random-song/random-song.component';
 
 
 @NgModule({
@@ -114,7 +115,8 @@ import { GradeElectoralComponent } from './components/constitution-page/results/
   	ScatterComponent,
 		ResultsFavoritesComponent,
 		PieComponent,
-		GradeElectoralComponent
+		GradeElectoralComponent,
+  RandomSongComponent
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/constitution-page/constitution.component.html
+++ b/src/app/components/constitution-page/constitution.component.html
@@ -6,12 +6,21 @@
 		</a>
 	</ng-template>
 	<span class="custom-br"></span>
-	Nombre de chansons : <br>
-	Constitution : {{songs.size}} / {{constitution.numberOfSongsPerUser * constitution.maxUserCount}}
-	<br>
-	Vous : {{numberOfSongsOfCurrentUser()}} / {{constitution.numberOfSongsPerUser}}
-	<br>
-	<span class="custom-br"></span>
+	<table class="custom-br2">
+		<tr>
+			<td> Constitution </td>
+			<td> {{songs.size}} / {{constitution.numberOfSongsPerUser * constitution.maxUserCount}} </td>
+		</tr>
+		<tr>
+			<td> Mes chansons </td>
+			<td> {{numberOfSongsOfCurrentUser()}} / {{constitution.numberOfSongsPerUser}} </td>
+		</tr>
+		<tr>
+			<td> Mes favoris </td>
+			<td> {{numberOfCurrentUserFavorites()}} / {{numberOfMaxFavorites()}} </td>
+		</tr>
+	</table>
+	<span class="custom-br custom-br2"></span>
 	<br>
 	<button mat-raised-button color="primary" [disabled]="!updateSongs()" (click)="openDialogManageSongs()">
 		<mat-icon>apps</mat-icon> Gérer mes chansons

--- a/src/app/components/constitution-page/constitution.component.html
+++ b/src/app/components/constitution-page/constitution.component.html
@@ -27,7 +27,7 @@
 	</button>
 	<br>
 	<br>
-	<button mat-raised-button [disabled]="true" color="primary">
+	<button mat-raised-button color="primary" (click)="openDialogRandomSong()">
 		<mat-icon>shuffle</mat-icon> Sélection Aléatoire
 	</button>
 	<br>

--- a/src/app/components/constitution-page/constitution.component.scss
+++ b/src/app/components/constitution-page/constitution.component.scss
@@ -79,3 +79,12 @@
   text-align: left;
   overflow-x: auto;
 }
+
+table {
+  margin-left: auto;
+  margin-right: auto;
+  width: 65%;
+  overflow-x: auto;
+  align-items: center;
+  border: 2px solid $sasuke;
+}

--- a/src/app/components/constitution-page/constitution.component.scss
+++ b/src/app/components/constitution-page/constitution.component.scss
@@ -87,4 +87,5 @@ table {
   overflow-x: auto;
   align-items: center;
   border: 2px solid $sasuke;
+  background-color: $bg-dark;
 }

--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -2,7 +2,7 @@
 import { Component, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute} from '@angular/router';
-import { canModifySongs, Constitution, createMessage, CstReqGet, CstResUpdate, CstSongReqGetAll, CstSongResUpdate, EMPTY_CONSTITUTION, EventType, extractMessageData, Message, OWNER_INDEX, Role, Song, User, UsrReqGet, UsrReqUnsubscribe, UsrResUpdate, CstFavResUpdate, CstFavReqGet, UserFavorites, CstSongReqUnsubscribe, CstFavReqUnsubscribe } from 'chelys';
+import { canModifySongs, Constitution, createMessage, CstReqGet, CstResUpdate, CstSongReqGetAll, CstSongResUpdate, EMPTY_CONSTITUTION, EventType, extractMessageData, Message, OWNER_INDEX, Role, Song, User, UsrReqGet, UsrReqUnsubscribe, UsrResUpdate, CstFavResUpdate, CstFavReqGet, UserFavorites, CstSongReqUnsubscribe, CstFavReqUnsubscribe, FAVORITES_MAX_LENGTH } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { ManageSongsComponent } from './manage-songs/manage-songs.component';
 
@@ -161,6 +161,14 @@ export class ConstitutionComponent implements OnDestroy {
 
 	numberOfSongsOfCurrentUser(): number {
 		return Array.from(this.songs.values()).filter(song => song.user === this.auth.uid).length;
+	}
+
+	numberOfCurrentUserFavorites(): number {
+		return this.favorites.get(this.auth.uid)?.favs.length || 0;
+	}
+
+	numberOfMaxFavorites(): number {
+		return FAVORITES_MAX_LENGTH;
 	}
 
 	updateSongs(): boolean {

--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute} from '@angular/router';
 import { canModifySongs, Constitution, createMessage, CstReqGet, CstResUpdate, CstSongReqGetAll, CstSongResUpdate, EMPTY_CONSTITUTION, EventType, extractMessageData, Message, OWNER_INDEX, Role, Song, User, UsrReqGet, UsrReqUnsubscribe, UsrResUpdate, CstFavResUpdate, CstFavReqGet, UserFavorites, CstSongReqUnsubscribe, CstFavReqUnsubscribe, FAVORITES_MAX_LENGTH } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { ManageSongsComponent } from './manage-songs/manage-songs.component';
+import { RandomSongComponent } from './random-song/random-song.component';
 
 enum ConstitutionSection {
 	SONG_LIST,
@@ -136,6 +137,18 @@ export class ConstitutionComponent implements OnDestroy {
 		}
 
 		this.dialog.open(ManageSongsComponent, config);
+	}
+
+	openDialogRandomSong(): void {
+		const config = new MatDialogConfig();
+
+		config.data = {
+			constitution: this.constitution,
+			songs: Array.from(this.songs.values()),
+			favorites: this.favorites.get(this.auth.uid),
+		}
+
+		this.dialog.open(RandomSongComponent, config);
 	}
 
 	setCurrentSection(newSection: ConstitutionSection): void {

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.html
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.html
@@ -71,7 +71,7 @@
 			</table>
 			<br>
 			<button mat-raised-button color="warn" (click)="closeWindow()">
-				<mat-icon>cancel</mat-icon>
+				Annuler
 			</button>
 		</mat-tab>
 		<mat-tab label="Modifier" [disabled]="true">

--- a/src/app/components/constitution-page/random-song/random-song.component.html
+++ b/src/app/components/constitution-page/random-song/random-song.component.html
@@ -12,7 +12,7 @@
   </iframe>
   <br>
   <button mat-raised-button color="primary" class="margin" matTooltip="Chanson aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
-  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorties() || canModifyFavorite()">
+  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorties() || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
   </button>
 </div>

--- a/src/app/components/constitution-page/random-song/random-song.component.html
+++ b/src/app/components/constitution-page/random-song/random-song.component.html
@@ -1,0 +1,25 @@
+<div class="title">
+  <a href="{{currentSong.url}}" target="_blank">
+    <h1> {{currentSong.title}} - {{currentSong.author}} </h1>
+  </a>
+<span class="custom-br"></span>
+</div>
+<br>
+<div class="title">
+  <iframe width="640" height="360" frameborder="0"
+      [src]="currentSongSafeURL"
+      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+  </iframe>
+  <br>
+  <button mat-raised-button color="primary" class="margin" matTooltip="Chanson aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
+  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorties() || canModifyFavorite()">
+    <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
+  </button>
+</div>
+<button mat-raised-button color="primary" (click)="closeWindow()">
+  Fermer
+</button>
+
+<ng-template #normalSong>
+	<mat-icon>favorite_border</mat-icon>
+</ng-template>

--- a/src/app/components/constitution-page/random-song/random-song.component.scss
+++ b/src/app/components/constitution-page/random-song/random-song.component.scss
@@ -1,0 +1,3 @@
+.margin {
+  margin-right: 2%;
+}

--- a/src/app/components/constitution-page/random-song/random-song.component.spec.ts
+++ b/src/app/components/constitution-page/random-song/random-song.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RandomSongComponent } from './random-song.component';
+
+describe('RandomSongComponent', () => {
+  let component: RandomSongComponent;
+  let fixture: ComponentFixture<RandomSongComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RandomSongComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RandomSongComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/constitution-page/random-song/random-song.component.ts
+++ b/src/app/components/constitution-page/random-song/random-song.component.ts
@@ -6,46 +6,45 @@ import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
 import { getEmbedURL } from 'src/app/types/url';
 
-interface SongNavigatorInjectedData {
+interface RandomSongInjectedData {
 	constitution: Constitution,
-	currentSong: Song,
 	songs: Song[],
 	favorites: UserFavorites
 }
 
 @Component({
-	selector: 'app-song-navigator',
-	templateUrl: './song-navigator.component.html',
-	styleUrls: ['./song-navigator.component.scss']
+  selector: 'app-random-song',
+  templateUrl: './random-song.component.html',
+  styleUrls: ['./random-song.component.scss']
 })
-export class SongNavigatorComponent implements OnDestroy {
+export class RandomSongComponent implements OnDestroy {
 
-	constitution: Constitution;
+  constitution: Constitution;
 	currentSong: Song;
 	currentSongSafeURL: SafeResourceUrl;
 	songs: Song[];
 	favorites: UserFavorites;
 
-	constructor(
-		private auth: AuthService,
-		private sanitizer: DomSanitizer,
-		private dialogRef: MatDialogRef<SongNavigatorComponent>,
-		@Inject(MAT_DIALOG_DATA) public data: SongNavigatorInjectedData,
-	) {
-		this.constitution = data.constitution;
-		this.currentSong = data.currentSong;
-		this.songs = data.songs;
-		this.favorites = data.favorites;
-		this.currentSongSafeURL = getEmbedURL(this.currentSong, this.sanitizer);
+  constructor(
+    private auth: AuthService,
+    private sanitizer: DomSanitizer,
+		private dialogRef: MatDialogRef<RandomSongComponent>,
+		@Inject(MAT_DIALOG_DATA) public data: RandomSongInjectedData
+    ) {
+      this.constitution = data.constitution;
+      this.songs = data.songs;
+      this.favorites = data.favorites;
+      this.currentSong = this.songs[Math.floor(Math.random() * this.songs.length)];
+      this.currentSongSafeURL = getEmbedURL(this.currentSong, this.sanitizer);
 
-		this.auth.pushEventHandler(this.handleEvent, this);
-	}
+      this.auth.pushEventHandler(this.handleEvent, this);
+    }
 
-	ngOnDestroy(): void {
+  ngOnDestroy(): void {
 		this.auth.popEventHandler();
 	}
 
-	handleEvent(event: MessageEvent<any>): void {
+  handleEvent(event: MessageEvent<any>): void {
 		let message = JSON.parse(event.data.toString()) as Message<unknown>;
 
 		switch (message.event) {
@@ -56,26 +55,16 @@ export class SongNavigatorComponent implements OnDestroy {
 		}
 	}
 
-	previousSongExist(): boolean {
-		const index = this.songs.lastIndexOf(this.currentSong);
-		return index - 1 >= 0;
-	}
-
-  nextSongExist(): boolean {
-    const index = this.songs.lastIndexOf(this.currentSong);
-    return index + 1 < this.songs.length;
-  }
-
-	changeSong(shift: number): void {
-		const currentIndex = this.songs.lastIndexOf(this.currentSong);
-
-		this.currentSong = this.songs[currentIndex + shift];
+	changeSong(): void {
+		this.currentSong = this.songs[Math.floor(Math.random() * this.songs.length)];
 		this.currentSongSafeURL = getEmbedURL(this.currentSong, this.sanitizer);
 	}
 
-	closeWindow(): void {
+  closeWindow(): void {
 		this.dialogRef.close();
 	}
+
+	// TODO : DUPLICATION DE CODE
 
 	isAFavorite(): boolean {
 		if (isNil(this.favorites)) return false;

--- a/src/app/components/constitution-page/random-song/random-song.component.ts
+++ b/src/app/components/constitution-page/random-song/random-song.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { areResultsPublic, Constitution, createMessage, CstFavReqAdd, CstFavReqRemove, CstFavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, Message, Song, UserFavorites } from 'chelys';
+import { areResultsPublic, canModifySongs, Constitution, createMessage, CstFavReqAdd, CstFavReqRemove, CstFavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, Message, Song, UserFavorites } from 'chelys';
 import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
 import { getEmbedURL } from 'src/app/types/url';
@@ -93,7 +93,7 @@ export class RandomSongComponent implements OnDestroy {
 	}
 
 	canModifyFavorite(): boolean {
-		return areResultsPublic(this.constitution);
+		return !canModifySongs(this.constitution) && !areResultsPublic(this.constitution);
 	}
 
 }

--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -59,7 +59,7 @@
 							<button mat-raised-button color="primary" (click)="onNavigate(song)">
 								<mat-icon>play_circle_outline</mat-icon>
 							</button>
-							<button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorites(song) || canModifyFavorite()">
+							<button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorites(song) || !canModifyFavorite()">
 									<mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
 							</button>
 							<button *ngIf="isCurrentUserSong(song)" [disabled]="!canDeleteSong()" mat-raised-button color="warn" class="cancel" (click)="openDeleteSongWarning(song)">

--- a/src/app/components/constitution-page/song-list/song-list.component.ts
+++ b/src/app/components/constitution-page/song-list/song-list.component.ts
@@ -123,7 +123,7 @@ export class SongListComponent {
 	}
 
 	canModifyFavorite(): boolean {
-		return areResultsPublic(this.constitution);
+		return !canModifySongs(this.constitution) && !areResultsPublic(this.constitution);
 	}
 
 	updateCurrentIframeSong(song: Song): void {

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
@@ -13,7 +13,7 @@
   <br>
   <br>
   <button mat-button class="previous-button" color="primary" [disabled]="!previousSongExist()" (click)="changeSong(-1)"> <mat-icon>keyboard_arrow_left</mat-icon> </button>
-  <button mat-raised-button class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorties() || canModifyFavorite()">
+  <button mat-raised-button class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorties() || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
   </button>
   <button mat-button class="next-button" color="primary" [disabled]="!nextSongExist()" (click)="changeSong(1)"> <mat-icon>keyboard_arrow_right</mat-icon> </button>

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { areResultsPublic, Constitution, createMessage, CstFavReqAdd, CstFavReqRemove, CstFavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, Message, Song, UserFavorites } from 'chelys';
+import { areResultsPublic, canModifySongs, Constitution, createMessage, CstFavReqAdd, CstFavReqRemove, CstFavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, Message, Song, UserFavorites } from 'chelys';
 import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
 import { getEmbedURL } from 'src/app/types/url';
@@ -104,7 +104,7 @@ export class SongNavigatorComponent implements OnDestroy {
 	}
 
 	canModifyFavorite(): boolean {
-		return areResultsPublic(this.constitution);
+		return !canModifySongs(this.constitution) && !areResultsPublic(this.constitution);
 	}
 
 }

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -87,7 +87,7 @@
                 <button mat-raised-button color="primary" (click)="openVoteNavigator(song)">
                   <mat-icon>how_to_vote</mat-icon>
                 </button>
-                <button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorties(song) || canModifyFavorite()">
+                <button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorties(song) || !canModifyFavorite()">
 									<mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
 							  </button>
                 <button mat-raised-button color="primary" class="vote" [matMenuTriggerFor]="menu" matTooltip="Classer les votes">

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -200,7 +200,7 @@ export class VotesGradeComponent implements OnDestroy {
 	}
 
 	canModifyFavorite(): boolean {
-		return areResultsPublic(this.constitution);
+		return !canModifySongs(this.constitution) && !areResultsPublic(this.constitution);
 	}
 
 	// TODO : Duplication de code //

--- a/src/app/components/delete-song-warning/delete-song-warning.component.html
+++ b/src/app/components/delete-song-warning/delete-song-warning.component.html
@@ -5,7 +5,7 @@
   Cette action est <span class="warning"> irréversible</span>.
   <br>
   <br>
-  <button mat-raised-button color="warn" (click)="deleteSong()"> Retirer </button>
+  <button mat-raised-button color="warn" class="margin" (click)="deleteSong()"> Retirer </button>
   <button mat-raised-button color="primary" (click)="closeWindow()"> Annuler </button>
 </div>
 

--- a/src/app/components/delete-song-warning/delete-song-warning.component.scss
+++ b/src/app/components/delete-song-warning/delete-song-warning.component.scss
@@ -1,0 +1,3 @@
+.margin {
+  margin-right: 5%;
+}


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Bouton "Sélection Aléatoire" qui propose d'écouter les chansons d'une constitution de manière aléatoire. Il est aussi possible d'y mettre ses favoris.

### :tada: Quality of life
* Révision de l'interface qui affiche les informations de la constitution (nombre de chansons / nombre de favoris).

### :bug: Bugfix
* Il n'est plus possible de mettre des favoris durant la période d'ajouts d'une constitution pour éviter d'avoir des favoris fantômes si on supprime une chanson.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie