### PR TITLE
Ajout d'une visualisation des relations en Graphe

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -80,6 +80,7 @@ import { AppRoutingModule } from './app-routing.module';
 
 // Services
 import { AuthService } from './services/auth.service';
+import { ChordComponent } from './components/template/chord/chord.component';
 
 
 
@@ -121,7 +122,8 @@ import { AuthService } from './services/auth.service';
 		GradeElectoralComponent,
   	RandomSongComponent,
    	GradeRelationshipComponent,
-   	HeatmapComponent
+   	HeatmapComponent,
+    ChordComponent
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/constitution-page/results/results-favorites/results-favorites.component.html
+++ b/src/app/components/constitution-page/results/results-favorites/results-favorites.component.html
@@ -14,7 +14,7 @@
       </tr>
       <tr *ngFor="let info of tableInfo;let indexOfelement=index;">
         <td> {{ indexOfelement + 1 }} </td>
-        <td> <button mat-raised-button color="primary" class="disable-click"> <span> {{ info.users.length }} </span>  <mat-icon class="favorite"> favorite </mat-icon> </button> </td>
+        <td> <button mat-raised-button class="disable-click no-button-color"> <span> {{ info.users.length }} </span>  <mat-icon class="favorite"> favorite </mat-icon> </button> </td>
         <td> {{ getSong(info.song).title }} - {{ getSong(info.song).author }}  </td>
         <td>
           <a href="{{getSong(info.song).url}}" target="_blank">

--- a/src/app/components/constitution-page/results/results-favorites/results-favorites.component.scss
+++ b/src/app/components/constitution-page/results/results-favorites/results-favorites.component.scss
@@ -33,6 +33,11 @@ td, th {
   border-radius: 28px;
 }
 
+.no-button-color {
+  background-color: $mineshaft;
+  color: whitesmoke;
+}
+
 mat-select {
   color: whitesmoke;
 }

--- a/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.html
@@ -10,4 +10,10 @@
     </i>
     <app-heatmap [data]="heatmapData" [xAxis]="xAxisNames" [yAxis]="yAxisNames"> </app-heatmap>
   </mat-expansion-panel>
+  <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel-header> 
+        <mat-panel-title> ??? </mat-panel-title>
+    </mat-expansion-panel-header>
+    <app-chord [nodes]="nodes" [links]="links" [categories]="categories"> </app-chord>
+  </mat-expansion-panel>
 </mat-accordion>

--- a/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.html
@@ -14,6 +14,12 @@
     <mat-expansion-panel-header> 
         <mat-panel-title> ??? </mat-panel-title>
     </mat-expansion-panel-header>
-    <app-chord [nodes]="nodes" [links]="links" [categories]="categories"> </app-chord>
+    <b> (Beta) </b> <br>
+    <button mat-raised-button color="primary" class="margin" [disabled]="useForce" (click)="generateChord()"> Générer Nouveau Graphe </button>
+    <mat-checkbox color="primary" [checked]="useForce" class="margin" (change)="updateForce()"> Appliquer la force </mat-checkbox>
+    <mat-slider color="primary" [thumbLabel]="true" [max]="maxSliderValue" [(ngModel)]="sliderValue" aria-label="unit(s)" (change)="generateChord()"></mat-slider> Conserver les liens supérieur à <b> {{sliderValue}} </b>
+    <br>
+    <br>
+    <app-chord [nodes]="nodes" [links]="links" [categories]="categories" [useForce]="useForce"> </app-chord>
   </mat-expansion-panel>
 </mat-accordion>

--- a/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.scss
+++ b/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.scss
@@ -1,0 +1,3 @@
+.margin {
+  margin-right: 1cm;
+}

--- a/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, SimpleChanges } from '@angular/core';
 import { Song, User, UserFavorites } from 'chelys';
 import { isNil } from 'lodash';
-import { HeatmapData } from 'src/app/types/charts';
+import { ChordCategory, ChordLink, ChordNode, HeatmapData } from 'src/app/types/charts';
 import { SongGradeResult, UserGradeResults } from 'src/app/types/results';
 
 @Component({
@@ -11,19 +11,27 @@ import { SongGradeResult, UserGradeResults } from 'src/app/types/results';
 })
 export class GradeRelationshipComponent {
 
+  // Input
   @Input() users: Map<string, User> = new Map();
 	@Input() songs: Map<number, Song> = new Map();
   @Input() favorites: Map<string, UserFavorites> = new Map();
   @Input() userResults: Map<string, UserGradeResults> = new Map();
   @Input() songResults: SongGradeResult[] = [];
 
+  // Heatmap
   heatmapData: HeatmapData[] = [];
   xAxisNames: string[] = [];
   yAxisNames: string[] = [];
 
+  // Chord
+  categories: ChordCategory[] = [];
+  links: ChordLink[] = [];
+  nodes: ChordNode[] = [];
+
   ngOnChanges(changes: SimpleChanges): void {
     this.songResults = changes['songResults'].currentValue;
-    this.generateData();
+    this.generateHeatmap();
+    this.generateChord();
   }
 
   constructor() { }
@@ -40,7 +48,47 @@ export class GradeRelationshipComponent {
     return songs2.filter((song) => favorites1.includes(song)).length + songs2.filter((song) => results1.mean < (results1.data.values.get(song) || -1)).length;
   }
 
-  generateData() {
+  generateChord(): void {
+    this.categories = Array.from(this.users.values()).map((value) => {
+      return { name: value.displayName };
+    });
+
+    this.nodes = [];
+    this.links = [];
+    for (const user1 of this.users.values()) {
+      let totalCount = 0;
+      for (const user2 of this.users.values()) {
+        if (user1.uid === user2.uid) continue;
+        const count = this.countRelations(user1.uid, user2.uid);
+        if (count === 0) continue;
+        totalCount += count;
+        this.links.push({
+          source: user1.uid, 
+          target: user2.uid,
+          value: count,
+          lineStyle: {
+            width: count,
+            curveness: 0.5,
+            opacity: 0.7
+          }
+        });
+      }
+      this.nodes.push({
+        id: user1.uid,
+        name: user1.displayName,
+        symbolSize: 5 + totalCount,
+        value: totalCount,
+        x: Math.random() * 100,   // TODO
+        y: Math.random() * 100,   // TODO
+        category: this.nodes.length,
+        label: {
+          show: true
+        }
+      });
+    }
+  }
+
+  generateHeatmap(): void {
     this.heatmapData = [];
     this.xAxisNames = [];
     this.yAxisNames = [];
@@ -53,10 +101,10 @@ export class GradeRelationshipComponent {
     const users = Array.from(this.users.values());
 
     for (let i = 0; i < users.length; i++) {
-      const user1 = users[i];
+      const user1 = users[i].uid;
       for (let j = 0; j < users.length; j++) {
-        const user2 = users[j];
-        this.heatmapData.push([i, j, user1.uid === user2.uid ? 0 : this.countRelations(user1.uid, user2.uid)])
+        const user2 = users[j].uid;
+        this.heatmapData.push([i, j, user1 === user2 ? 0 : this.countRelations(user1, user2)])
       }
     }
   }

--- a/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.ts
@@ -23,10 +23,13 @@ export class GradeRelationshipComponent {
   xAxisNames: string[] = [];
   yAxisNames: string[] = [];
 
-  // Chord
+  // Graph
   categories: ChordCategory[] = [];
   links: ChordLink[] = [];
   nodes: ChordNode[] = [];
+  useForce: boolean = false;
+  sliderValue: number = 0;
+  maxSliderValue: number = 0;
 
   ngOnChanges(changes: SimpleChanges): void {
     this.songResults = changes['songResults'].currentValue;
@@ -61,26 +64,30 @@ export class GradeRelationshipComponent {
         if (user1.uid === user2.uid) continue;
         const count = this.countRelations(user1.uid, user2.uid);
         if (count === 0) continue;
+        if (this.maxSliderValue < count) this.maxSliderValue = count;
         totalCount += count;
-        this.links.push({
-          source: user1.uid, 
-          target: user2.uid,
-          value: count,
-          lineStyle: {
-            width: count,
-            curveness: 0.5,
-            opacity: 0.7
-          }
-        });
+        if (count > this.sliderValue) {
+          this.links.push({
+            source: user1.uid, 
+            target: user2.uid,
+            value: count,
+            lineStyle: {
+              width: count,
+              curveness: 0.5,
+              opacity: 0.7
+            }
+          });
+        }
+
       }
       this.nodes.push({
         id: user1.uid,
         name: user1.displayName,
         symbolSize: 5 + totalCount,
         value: totalCount,
-        x: Math.random() * 100,   // TODO
-        y: Math.random() * 100,   // TODO
-        category: this.nodes.length,
+        x: Math.random() * 80,   // TODO
+        y: Math.random() * 80,   // TODO
+        category: this.nodes.length, // Math.round(Math.random() * this.categories.length), // this.nodes.length,
         label: {
           show: true
         }
@@ -107,6 +114,10 @@ export class GradeRelationshipComponent {
         this.heatmapData.push([i, j, user1 === user2 ? 0 : this.countRelations(user1, user2)])
       }
     }
+  }
+
+  updateForce(): void {
+    this.useForce = !this.useForce;
   }
 
 }

--- a/src/app/components/template/chord/chord.component.html
+++ b/src/app/components/template/chord/chord.component.html
@@ -1,0 +1,1 @@
+<div id="chord" style="width:100%; height:900px;"></div>

--- a/src/app/components/template/chord/chord.component.spec.ts
+++ b/src/app/components/template/chord/chord.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChordComponent } from './chord.component';
+
+describe('ChordComponent', () => {
+  let component: ChordComponent;
+  let fixture: ComponentFixture<ChordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ChordComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/template/chord/chord.component.ts
+++ b/src/app/components/template/chord/chord.component.ts
@@ -14,6 +14,7 @@ export class ChordComponent implements AfterViewInit, OnChanges {
   @Input() categories: ChordCategory[] = [];
   @Input() links: ChordLink[] = [];
   @Input() nodes: ChordNode[] = [];
+  @Input() useForce: boolean = false;
 
   private chart: echarts.ECharts | undefined;
   private option: EChartsOption;
@@ -26,9 +27,11 @@ export class ChordComponent implements AfterViewInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    this.categories = changes['categories'].currentValue;
-    this.links = changes['links'].currentValue;
-    this.nodes = changes['nodes'].currentValue;
+    if (changes['categories']) this.categories = changes['categories'].currentValue;
+    if (changes['links']) this.links = changes['links'].currentValue;
+    if (changes['nodes']) this.nodes = changes['nodes'].currentValue;
+    if (changes['useForce']) this.useForce = changes['useForce'].currentValue;
+    
     this.ngAfterViewInit();
   }
 
@@ -38,45 +41,6 @@ export class ChordComponent implements AfterViewInit, OnChanges {
   }
 
   private initChart(): EChartsOption {
-    // return {
-    //   tooltip: {},
-    //   // legend: [
-    //   //   {
-    //   //     data: this.categories.map(function (a: { name: string }) {
-    //   //       return a.name;
-    //   //     }),
-    //   //     orient: 'vertical',
-    //   //     left: 'left',
-    //   //     textStyle: {
-    //   //       color: '#f4f4f4',
-    //   //     }
-    //   //   }
-    //   // ],
-    //   animationDurationUpdate: 1500,
-    //   animationEasingUpdate: 'quinticInOut',
-    //   series: [
-    //     {
-    //       type: 'graph',
-    //       layout: 'circular',
-    //       circular: {
-    //         rotateLabel: true
-    //       },
-    //       data: this.nodes,
-    //       links: this.links,
-    //       roam: true,
-    //       label: {
-    //         position: 'right',
-    //         formatter: '{b}'
-    //       },
-    //       lineStyle: {
-    //         color: 'source',
-    //         curveness: 0.3,
-    //         width: 3
-    //       }
-    //     }
-    //   ]
-    // };
-
     return {
       tooltip: {},
       legend: [
@@ -93,13 +57,13 @@ export class ChordComponent implements AfterViewInit, OnChanges {
       ],
       series: [
         {
-          // name: 'Les Miserables',
           type: 'graph',
-          layout: 'force',
+          layout: this.useForce ? 'force' : 'none',
           data: this.nodes,
-          links: this.links,
+          edges: this.links,
           categories: this.categories,
-          roam: true,
+          // roam: true,
+          draggable: true,
           label: {
             show: true,
             position: 'right',
@@ -116,9 +80,12 @@ export class ChordComponent implements AfterViewInit, OnChanges {
           lineStyle: {
             color: 'source'
           },
-          // force: {
-             // repulsion: 10
-          // }
+          force: {
+            // repulsion: 50,
+            // edgeLength: 5,
+            // repulsion: 20,
+            // gravity: 0.2
+          }
         }
       ]
     };

--- a/src/app/components/template/chord/chord.component.ts
+++ b/src/app/components/template/chord/chord.component.ts
@@ -1,0 +1,128 @@
+import { AfterViewInit, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import * as echarts from 'echarts';
+import { isNil } from 'lodash';
+import { EChartsOption } from 'echarts';
+import { ChordCategory, ChordLink, ChordNode } from 'src/app/types/charts';
+
+@Component({
+  selector: 'app-chord',
+  templateUrl: './chord.component.html',
+  styleUrls: ['./chord.component.scss']
+})
+export class ChordComponent implements AfterViewInit, OnChanges {
+
+  @Input() categories: ChordCategory[] = [];
+  @Input() links: ChordLink[] = [];
+  @Input() nodes: ChordNode[] = [];
+
+  private chart: echarts.ECharts | undefined;
+  private option: EChartsOption;
+
+  ngAfterViewInit() {
+    if (isNil(this.chart)) this.chart = echarts.init(document.getElementById('chord')!);
+    
+    this.option = this.initChart();
+    this.option && this.chart.setOption(this.option);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    this.categories = changes['categories'].currentValue;
+    this.links = changes['links'].currentValue;
+    this.nodes = changes['nodes'].currentValue;
+    this.ngAfterViewInit();
+  }
+
+  constructor() {
+    this.chart = undefined;
+    this.option = {};
+  }
+
+  private initChart(): EChartsOption {
+    // return {
+    //   tooltip: {},
+    //   // legend: [
+    //   //   {
+    //   //     data: this.categories.map(function (a: { name: string }) {
+    //   //       return a.name;
+    //   //     }),
+    //   //     orient: 'vertical',
+    //   //     left: 'left',
+    //   //     textStyle: {
+    //   //       color: '#f4f4f4',
+    //   //     }
+    //   //   }
+    //   // ],
+    //   animationDurationUpdate: 1500,
+    //   animationEasingUpdate: 'quinticInOut',
+    //   series: [
+    //     {
+    //       type: 'graph',
+    //       layout: 'circular',
+    //       circular: {
+    //         rotateLabel: true
+    //       },
+    //       data: this.nodes,
+    //       links: this.links,
+    //       roam: true,
+    //       label: {
+    //         position: 'right',
+    //         formatter: '{b}'
+    //       },
+    //       lineStyle: {
+    //         color: 'source',
+    //         curveness: 0.3,
+    //         width: 3
+    //       }
+    //     }
+    //   ]
+    // };
+
+    return {
+      tooltip: {},
+      legend: [
+        {
+          data: this.categories.map(function (a) {
+            return a.name;
+          }),
+          orient: 'vertical',
+          left: 'left',
+          textStyle: {
+            color: '#f4f4f4',
+          }
+        }
+      ],
+      series: [
+        {
+          // name: 'Les Miserables',
+          type: 'graph',
+          layout: 'force',
+          data: this.nodes,
+          links: this.links,
+          categories: this.categories,
+          roam: true,
+          label: {
+            show: true,
+            position: 'right',
+            formatter: '{b}',
+            color: '#f4f4f4'
+          },
+          labelLayout: {
+            hideOverlap: true
+          },
+          scaleLimit: {
+            min: 0.4,
+            max: 2
+          },
+          lineStyle: {
+            color: 'source'
+          },
+          // force: {
+             // repulsion: 10
+          // }
+        }
+      ]
+    };
+  }
+
+
+}

--- a/src/app/types/charts.ts
+++ b/src/app/types/charts.ts
@@ -4,6 +4,35 @@ export const CHARTS_ID_LENGTH = 12;
 
 export type EChartsOption = echarts.EChartsOption;
 
+// Chord
+export type ChordCategory = {
+  name: string;
+}
+
+export type ChordLink = {
+  source: string;
+  target: string;
+  lineStyle: {
+    width: number,
+    curveness: number,
+    opacity: number
+  },
+  value: number;
+}
+
+export type ChordNode = {
+  id: string;
+  name: string;
+  symbolSize: number;
+  x: number;
+  y: number;
+  value: number;
+  category: number;
+  label: {
+    show: boolean;
+  }
+}
+
 // Heatmap
 export type HeatmapData = [
   number, // y

--- a/src/app/types/charts.ts
+++ b/src/app/types/charts.ts
@@ -24,8 +24,8 @@ export type ChordNode = {
   id: string;
   name: string;
   symbolSize: number;
-  x: number;
-  y: number;
+  x: number | undefined;
+  y: number | undefined;
   value: number;
   category: number;
   label: {


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

La visualisation par graphe n'est pas terminée mais aurait d'abord besoin de plus de feedback de la part de la communauté en condition réel afin de bien comprendre les besoins.

### :rocket: Nouveauté
* Ajout d'une visualisation des relations dans un graphe.

### :tada: Quality of life
* La visualisation par graphe possède plusieurs paramètres (re-générer les coordonnées, appliquer la force, retirer certains lien entre les noeuds) pour mieux les utiliser.

### :bug: Bugfix
* Dans la sous-page de la résultat dans l'onglet "Favoris", changement du fond de couleur en gris du compteur de favoris pour éviter de croire à un bouton. 

### :hammer_and_wrench: Refactoring
* Ajout d'un template pour générer les graphes.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie