### PR TITLE
Corrections mineures dans l'interface de la soirée électorale et de la heatmap

### DIFF
--- a/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
@@ -28,19 +28,19 @@
     <br>
     <table id="t01">
       <tr>
-        <th colspan="2"> Utilisateur </th>
-        <th> Score </th>
-        <th> Note </th>
+        <th colspan="2" style="width: 70%;"> Utilisateur </th>
+        <th style="width: 15%;"> Score </th>
+        <th style="width: 15%;"> Note </th>
       </tr>
       <tr *ngFor="let votingUser of currentVoters">
-        <td> <img class="picture" [src]="votingUser.user.photoURL"> </td>
-        <td> {{ votingUser.user.displayName }} </td>
-        <td> {{ votingUser.score.toFixed(3) }}</td>
-        <td> {{ votingUser.grade }}</td>
+        <td style="width: 15%;"> <img class="picture" [src]="votingUser.user.photoURL"> </td>
+        <td style="width: 55%;"> {{ votingUser.user.displayName }} </td>
+        <td style="width: 15%;"> {{ votingUser.score.toFixed(3) }}</td>
+        <td style="width: 15%;"> {{ votingUser.grade }}</td>
       </tr>
       <tr>
         <td> </td>
-        <td> <b> Total: </b> </td>
+        <td> <b> Total/Moyenne: </b> </td>
         <td> <b> {{songResults[currentRank].score.toFixed(3)}} </b> </td>
         <td> <b> {{meanOfVotes().toFixed(3)}} </b></td>
       </tr>

--- a/src/app/components/template/heatmap/heatmap.component.ts
+++ b/src/app/components/template/heatmap/heatmap.component.ts
@@ -45,9 +45,7 @@ export class HeatmapComponent implements AfterViewInit, OnChanges  {
 
   private initChart(): EChartsOption {
     return {
-      tooltip: {
-        // position: 'top'
-      },
+      tooltip: {},
       grid: {
         height: '50%',
         top: '10%'
@@ -79,7 +77,6 @@ export class HeatmapComponent implements AfterViewInit, OnChanges  {
       },
       series: [
         {
-          name: 'Punch Card',
           type: 'heatmap',
           data: this.data,
           label: {


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* La longueur des colonnes de la table des notes des utilisateurs dans une soirée électorale est désormais fixe et ne varie plus en fonction des utilisateurs présents.

### :bug: Bugfix
* Retrait du titre "Punch Card" du hover d'une case de la heatmap

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie