### PR TITLE
Correction pour 7ème Xénocratie

### DIFF
--- a/src/app/components/admin-page/new-constitution/new-constitution.component.ts
+++ b/src/app/components/admin-page/new-constitution/new-constitution.component.ts
@@ -25,7 +25,7 @@ export class NewConstitutionComponent {
 		this.newConstitutionForm = this.fb.group({
 			season: [, Validators.required],
 			part: [, Validators.required],
-			name: [, [Validators.required, Validators.maxLength(100)]],
+			name: [, [Validators.required, Validators.maxLength(30)]],
 			isPublic: [true, Validators.required],
 			anonymousLevel: [, Validators.required],
 			type: [, Validators.required],

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.html
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.html
@@ -13,7 +13,7 @@
 			<span class="custom-br"></span>
 			<form [formGroup]="newSongForm">
 				<br>
-				<mat-icon *ngIf="isNil('title')" class="icon">radio_button_unchecked</mat-icon>
+				<mat-icon *ngIf="isNil('title')" class="warning icon" matTooltip="Ce champ ne peut pas être vide.">error_outline</mat-icon>
 				<mat-icon *ngIf="!respectLengthLimit('title') && !isNil('title')" class="valid icon">check_circle_outline</mat-icon> 
 				<mat-icon *ngIf="respectLengthLimit('title')" class="warning icon" matTooltip="Attention, vous dépassez la limite de caractère (30). Kalimba n'enregistra que : {{showKalimbaValue('title')}}.">error_outline</mat-icon> 
 				<mat-form-field appearance="outline">
@@ -21,7 +21,7 @@
 					<input matInput formControlName="title" required>
 				</mat-form-field>
 				<br>
-				<mat-icon *ngIf="isNil('author')" class="icon">radio_button_unchecked</mat-icon>
+				<mat-icon *ngIf="isNil('author')" class="warning icon" matTooltip="Ce champ ne peut pas être vide.">error_outline</mat-icon>
 				<mat-icon *ngIf="!respectLengthLimit('author') && !isNil('author')" class="valid icon">check_circle_outline</mat-icon> 
 				<mat-icon *ngIf="respectLengthLimit('author')" class="warning icon" matTooltip="Attention, vous dépassez la limite de caractère (30). Kalimba n'enregistra que : {{showKalimbaValue('author')}}. ">error_outline</mat-icon> 
 				<mat-form-field appearance="outline">
@@ -29,7 +29,7 @@
 					<input matInput formControlName="author" required>
 				</mat-form-field>
 				<br>
-				<mat-icon *ngIf="isNil('url')" class="icon">radio_button_unchecked</mat-icon> 
+				<mat-icon *ngIf="isNil('url')" class="warning icon" matTooltip="Ce champ ne peut pas être vide.">error_outline</mat-icon> 
 				<mat-icon *ngIf="!isNotValidURL() && !isNil('url')" class="valid icon">check_circle_outline</mat-icon> 
 				<mat-icon *ngIf="isNotValidURL()" class="warning icon" matTooltip="Attention, l'URL entrée ne semble pas valide.">error_outline</mat-icon>
 				<mat-form-field appearance="outline">

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
@@ -94,10 +94,9 @@ export class ManageSongsComponent {
 
 	// VERIFY DATA
 		// TODO : HTML faire un template ?
-		// TODO : Gérer le cas où le champ est vide ?
 
 	isNil(key: string): boolean {
-		return isNil(this.newSongForm.value[key])
+		return isNil(this.newSongForm.value[key]) || this.newSongForm.value[key] === '';
 	}
 
 	respectLengthLimit(key: string): boolean {

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
@@ -7,8 +7,8 @@ import { AuthService } from 'src/app/services/auth.service';
 import { Status } from 'src/app/types/status';
 import { DEFAULT_ID_FROM_URL, getIDFromURL } from 'src/app/types/url';
 
-const SONG_NAME_LENGTH = 30;	// TODO : ADD TO CHELYS
-const SONG_AUTHOR_LENGTH = 30;
+const SONG_NAME_LENGTH = 100;	// TODO : ADD TO CHELYS
+const SONG_AUTHOR_LENGTH = 100;
 
 interface ManageSongsInjectedData {
 	cstID: string;

--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -31,12 +31,12 @@
 		<div class="row g-4">
 			<div class="col" *ngFor="let song of getSongs()">
 				<div class="card shadow-0 bg-dark z-card">
-					<h3 class="card-header front" class="text-overflowable">
+					<h3 class="card-header front">
 						<div>
-							{{song.title}}
+							<span class="text-overflowable"> {{song.title}} </span>
 							<img src="{{getUser(song.user).photoURL}}" class="image-de picture" matTooltip="{{getUser(song.user).displayName}}">
 						</div>
-						<i> {{song.author}} </i> 
+						<i class="text-overflowable"> {{song.author}} </i> 
 					</h3>
 					<img src="{{getImageURL(song)}}" class="card-img blur">
 					<div class="card-img-overlay">

--- a/src/app/components/constitution-page/song-list/song-list.component.scss
+++ b/src/app/components/constitution-page/song-list/song-list.component.scss
@@ -2,8 +2,8 @@
 
 .filter {
 	display: inline-block;
-	min-width: 75%;
 	margin-top: -5%;
+	width: 100%;
 
 	background-color: $bg-dark;
   border-radius: 25px;
@@ -11,7 +11,7 @@
 }
 
 .filter-text {
-	margin-left: 5%;
+	margin-left: 2%;
 	margin-top: 2%;
 	margin-right: 2%;
 }

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
@@ -1,6 +1,6 @@
-<div class="title" class="text-overflowable">
+<div class="title">
     <a href="{{currentSong.url}}" target="_blank">
-      <h1> {{currentSong.author}} - {{currentSong.title}} </h1>
+      <h1 class="text-overflowable"> {{currentSong.author}} - {{currentSong.title}} </h1>
     </a>
   <span class="custom-br"></span>
 </div>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -62,12 +62,12 @@
       <div class="row g-4">
         <div class="col" *ngFor="let song of getSongsToVote()">
           <div class="card shadow-0 bg-dark z-card">
-            <h3 class="card-header front" class="text-overflowable">
+            <h3 class="card-header front">
               <div>
-                {{song.title}}
+                <span class="text-overflowable"> {{song.title}} </span>
                 <img src="{{getUser(song.user).photoURL}}" class="image-de picture" matTooltip="{{getUser(song.user).displayName}}">
               </div>
-              <i> {{song.author}} </i> 
+              <i class="text-overflowable"> {{song.author}} </i> 
             </h3>
             <img src="{{getImageURL(song)}}" class="card-img blur">
             <div class="card-img-overlay">

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.scss
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.scss
@@ -123,7 +123,7 @@ mat-form-field {
 
 .filter {
 	display: inline-block;
-	min-width: 75%;
+	width: 100%;
 
 	background-color: $bg-dark;
   border-radius: 25px;
@@ -131,7 +131,7 @@ mat-form-field {
 }
 
 .filter-text {
-	margin-left: 5%;
+	margin-left: 2%;
 	margin-top: 2%;
 	margin-right: 2%;
 }


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* Lors de l'ajout des chansons il n'y a plus d'icône neutre pouvant faire penser à des radios buttons.
* La barre de filtrage des utilisateurs et des chansons occupe désormais 100% de l'espace alloué pour mieux accommoder les petits écrans.

### :bug: Bugfix
* Correction de l'utilisation de `text-overflowable` introduit en #52
* Correction du nombre de caractère pour le titre et auteur des chansons et du nom d'une constitution introduit en #52 

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie