### PR TITLE
Ordonner par favoris

### DIFF
--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -76,6 +76,7 @@
 	<table id="t01">
 		<tr>
 			<th> ID </th>
+			<th> Favoris </th>
 			<th> Titre </th>
 			<th> Auteur </th>
 			<th> URL </th>
@@ -83,6 +84,11 @@
 		</tr>
 		<tr *ngFor="let song of getSongs()">
 			<td> {{ song.id }} </td>
+			<td>
+				<button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorites(song) || !canModifyFavorite()">
+					<mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
+			</button>
+			</td>
 			<td> 
 				<button mat-raised-button color="primary" (click)="openSongNavigator(song)">
 					{{ song.title }} 

--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -16,7 +16,11 @@
 			<mat-icon class="menu-panel">list</mat-icon>
 			<span>Classer par utilisateur</span>
 		</button>
-		<button mat-menu-item class="menu-panel" (click)="setOrderByUser(false)">
+		<button mat-menu-item class="menu-panel" (click)="setOrderByFavs(true)">
+			<mat-icon class="menu-panel">favorite</mat-icon>
+			<span>Classer par favori</span>
+		</button>
+		<button mat-menu-item class="menu-panel" (click)="resetOrder()">
 			<mat-icon class="menu-panel">replay</mat-icon>
 			<span>Réinitialiser</span>
 		</button>

--- a/src/app/components/constitution-page/song-list/song-list.component.ts
+++ b/src/app/components/constitution-page/song-list/song-list.component.ts
@@ -34,6 +34,7 @@ export class SongListComponent {
 	// Filter
 	selectedUsers: string[];
 	orderByUser: boolean;
+	orderByFavs: boolean;
 
 	constructor(
 		private sanitizer: DomSanitizer,
@@ -46,6 +47,7 @@ export class SongListComponent {
 		this.cardsSortASC = (localStorage.getItem(CARDS_SORT_KEY) ?? true) === "false";
 		this.selectedUsers = Array.from(this.users.keys());
 		this.orderByUser = false;
+		this.orderByFavs = false;
 	}
 
 	getSongs(): Song[] {
@@ -57,6 +59,12 @@ export class SongListComponent {
 		else songs = songs.sort(compareSongDSC);
 
 		if (this.orderByUser) songs = songs.sort(compareSongUser);
+
+		if (this.orderByFavs) songs = songs.sort((a, b) => {
+			if (this.isAFavorite(a)) return -1;
+			if (this.isAFavorite(b)) return 1;
+			return 0; 
+		})
 
 		return songs;
 	}
@@ -158,6 +166,15 @@ export class SongListComponent {
 
 	setOrderByUser(order: boolean) {
 		this.orderByUser = order;
+	}
+
+	setOrderByFavs(order: boolean) {
+		this.orderByFavs = order;
+	}
+
+	resetOrder() {
+		this.setOrderByUser(false);
+		this.setOrderByFavs(false);
 	}
 
 	isAFavorite(song: Song): boolean {

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -47,6 +47,14 @@
         <mat-icon class="menu-panel">list</mat-icon>
         <span>Classer par utilisateur</span>
       </button>
+      <button mat-menu-item class="menu-panel" (click)="setOrderByGrade(0)">
+        <mat-icon class="menu-panel">trending_up</mat-icon>
+        <span>Classer par ordre croissant</span>
+      </button>
+      <button mat-menu-item class="menu-panel" (click)="setOrderByGrade(1)">
+        <mat-icon class="menu-panel">trending_down</mat-icon>
+        <span>Classer par ordre décroissant</span>
+      </button>
       <button mat-menu-item class="menu-panel" (click)="setOrderByUser(false)">
         <mat-icon class="menu-panel">replay</mat-icon>
         <span>Réinitialiser</span>
@@ -118,6 +126,7 @@
     <table id="t01">
       <tr>
         <th> ID </th>
+        <th> Favoris </th>
         <th> Titre </th>
         <th> Auteur </th>
         <th> URL </th>
@@ -125,6 +134,11 @@
       </tr>
       <tr *ngFor="let song of getSongsToVote()">
         <td> {{ song.id }} </td>
+        <td>
+          <button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorties(song) || !canModifyFavorite()">
+            <mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
+          </button>
+        </td>
         <td> 
           <button mat-raised-button color="primary" (click)="openVoteNavigator(song)">
             {{ song.title }} 

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -47,6 +47,10 @@
         <mat-icon class="menu-panel">list</mat-icon>
         <span>Classer par utilisateur</span>
       </button>
+      <button mat-menu-item class="menu-panel" (click)="setOrderByFavs(true)">
+        <mat-icon class="menu-panel">favorite</mat-icon>
+        <span>Classer par favori</span>
+      </button>
       <button mat-menu-item class="menu-panel" (click)="setOrderByGrade(0)">
         <mat-icon class="menu-panel">trending_up</mat-icon>
         <span>Classer par ordre croissant</span>
@@ -55,7 +59,7 @@
         <mat-icon class="menu-panel">trending_down</mat-icon>
         <span>Classer par ordre décroissant</span>
       </button>
-      <button mat-menu-item class="menu-panel" (click)="setOrderByUser(false)">
+      <button mat-menu-item class="menu-panel" (click)="resetOrder()">
         <mat-icon class="menu-panel">replay</mat-icon>
         <span>Réinitialiser</span>
       </button>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -44,8 +44,10 @@ export class VotesGradeComponent implements OnDestroy {
 	showStats: boolean;
 	showAlreadyVoted: boolean;
 
-	selectedUsers: string[];
+	// Filter
+	selectedUsers: string[];	// TODO : Meilleur manière de filtrer ?
 	orderByUser: boolean;
+	orderByFavs: boolean;
 	orderByGrade: GradeOrder;
 
 	constructor(
@@ -64,6 +66,7 @@ export class VotesGradeComponent implements OnDestroy {
 		this.showAlreadyVoted = (localStorage.getItem(GRADE_ALREADY_VOTES_KEY) ?? true) === "true";
 		this.selectedUsers = Array.from(this.users.keys());
 		this.orderByUser = false;
+		this.orderByFavs = false;
 		this.orderByGrade = GradeOrder.NONE;
 
 		this.auth.pushAuthFunction(this.onConnect, this);
@@ -140,6 +143,12 @@ export class VotesGradeComponent implements OnDestroy {
 			if (g1 < g2) return -order;
 
 			return 0;
+		})
+
+		if (this.orderByFavs) songsToVote = songsToVote.sort((a, b) => {
+			if (this.isAFavorite(a)) return -1;
+			if (this.isAFavorite(b)) return 1;
+			return 0; 
 		})
 
 		return songsToVote;
@@ -262,6 +271,15 @@ export class VotesGradeComponent implements OnDestroy {
 
 	setOrderByUser(order: boolean) {
 		this.orderByUser = order;
+	}
+
+	setOrderByFavs(order: boolean) {
+		this.orderByFavs = order;
+	}
+
+	resetOrder() {
+		this.setOrderByUser(false);
+		this.setOrderByFavs(false);
 	}
 	
 	// TODO : Implement class ?


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Il est désormais possible d'ordonner les chansons en mettant en avant les favoris.

### :tada: Quality of life
* Ajout des favoris dans la vue par tables.
* Déplacement des ordres sur les notes dans les filtres des utilisateurs. Ajout aussi le même support pour les tables.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie