### PR TITLE
Onglet d'export des chansons d'une constitution

### DIFF
--- a/src/app/components/constitution-page/constitution.component.html
+++ b/src/app/components/constitution-page/constitution.component.html
@@ -74,7 +74,7 @@
 							(click)="setCurrentSection(constitutionSection.RESULTS)">
 				<mat-icon>equalizer</mat-icon> Résultats
 			</button>
-			<button mat-button [disabled]="true" [ngClass]="isSectionActive(constitutionSection.EXPORT) ? 'active' : ''" 
+			<button mat-button [ngClass]="isSectionActive(constitutionSection.EXPORT) ? 'active' : ''" 
 							(click)="setCurrentSection(constitutionSection.EXPORT)">
 				<mat-icon>get_app</mat-icon> Exporter
 			</button>
@@ -98,6 +98,8 @@
 	<app-results *ngSwitchCase="constitutionSection.RESULTS"
 		[songs]="songs" [users]="users" [constitution]="constitution" [favorites]="favorites">
 	</app-results>
-	<app-export *ngSwitchCase="constitutionSection.EXPORT"> </app-export>
+	<app-export *ngSwitchCase="constitutionSection.EXPORT"
+		[songs]="songs" [users]="users" [constitution]="constitution">
+	</app-export>
 	<app-parameters *ngSwitchCase="constitutionSection.PARAMETERS"> </app-parameters>
 </div>

--- a/src/app/components/constitution-page/export/export.component.html
+++ b/src/app/components/constitution-page/export/export.component.html
@@ -1,1 +1,17 @@
-<p>export works!</p>
+<div>
+  <h1 class="title"> EXPORT </h1>
+  <span class="custom-br"></span>
+  <br>
+  Choisissez le format d'export :
+  <mat-form-field appearance="outline" class="typeField">
+    <mat-select [(value)]="selectedFormat">
+      <mat-option *ngFor="let format of availableFormat" value="{{format.format}}"> {{format.name}} </mat-option>
+    </mat-select>
+  </mat-form-field>
+  <br>
+  <button mat-raised-button color="primary" (click)="download()">
+    <mat-icon>get_app</mat-icon> Télécharger
+  </button>
+  <br> <br>
+  <span class="custom-br"></span>
+</div>

--- a/src/app/components/constitution-page/export/export.component.html
+++ b/src/app/components/constitution-page/export/export.component.html
@@ -2,14 +2,14 @@
   <h1 class="title"> EXPORT </h1>
   <span class="custom-br"></span>
   <br>
-  Choisissez le format d'export :
+  <span class="left"> Choisissez le format d'export : </span>
   <mat-form-field appearance="outline" class="typeField">
     <mat-select [(value)]="selectedFormat">
       <mat-option *ngFor="let format of availableFormat" value="{{format.format}}"> {{format.name}} </mat-option>
     </mat-select>
   </mat-form-field>
   <br>
-  <button mat-raised-button color="primary" (click)="download()">
+  <button mat-raised-button class="left" color="primary" (click)="download()">
     <mat-icon>get_app</mat-icon> Télécharger
   </button>
   <br> <br>

--- a/src/app/components/constitution-page/export/export.component.scss
+++ b/src/app/components/constitution-page/export/export.component.scss
@@ -1,0 +1,33 @@
+mat-select {
+  color: whitesmoke;
+}
+
+mat-select-value {
+  color: whitesmoke !important;
+}
+
+::ng-deep {
+  .mat-form-field-appearance-outline .mat-form-field-outline {
+     color: whitesmoke;
+  }
+  .mat-form-field.mat-focused .mat-form-field-label {
+      color: whitesmoke !important;
+  }
+  .mat-input-element {
+      caret-color: whitesmoke!important;
+  }
+
+  .mat-select-value {
+    color: whitesmoke;
+  }
+  .mat-select-arrow-wrapper {
+      color: whitesmoke;
+      background-color: whitesmoke;
+  }
+
+  mat-form-field {
+      .mat-hint, input, ::placeholder, .mat-form-field-label {
+          color: whitesmoke;
+      }
+  }
+}

--- a/src/app/components/constitution-page/export/export.component.scss
+++ b/src/app/components/constitution-page/export/export.component.scss
@@ -31,3 +31,7 @@ mat-select-value {
       }
   }
 }
+
+.left {
+  margin-left: 4%;
+}

--- a/src/app/components/constitution-page/export/export.component.ts
+++ b/src/app/components/constitution-page/export/export.component.ts
@@ -1,15 +1,100 @@
-import { Component, OnInit } from '@angular/core';
+// Source : https://stackblitz.com/edit/httpsstackoverflowcomquestions51806464how-to-create-and-downloa?file=src%2Fapp%2Fapp.component.ts
+import { Component, Input } from '@angular/core';
+import { Constitution, EMPTY_CONSTITUTION, Song, User } from 'chelys';
+
+enum ExportFormat {
+  NO_FORMAT,
+  CSV,
+  GOOGLE_SHEETS,
+  
+}
+
+const FORMATS = [
+  {
+    format: ExportFormat.CSV,
+    name: 'CSV'
+  },
+  {
+    format: ExportFormat.GOOGLE_SHEETS,
+    name: 'Google Sheets'
+  }
+]
 
 @Component({
   selector: 'app-export',
   templateUrl: './export.component.html',
   styleUrls: ['./export.component.scss']
 })
-export class ExportComponent implements OnInit {
+export class ExportComponent {
 
-  constructor() { }
+  @Input() constitution: Constitution = EMPTY_CONSTITUTION;
+  @Input() users: Map<string, User> = new Map();
+	@Input() songs: Map<number, Song> = new Map();
 
-  ngOnInit(): void {
+  availableFormat = FORMATS;
+  selectedFormat: ExportFormat;
+
+  private setting = {
+    element: {
+      dynamicDownload: null as unknown as HTMLElement
+    }
+  }
+
+  constructor() {
+    this.selectedFormat = ExportFormat.NO_FORMAT;
+  }
+
+  getUsername(uid: string): string {
+    return this.users.get(uid)?.displayName || "";
+  }
+
+  correctCSVField(field: string): string {
+    return field.includes(',') ? `"${field}"` : field;
+  }
+
+  toGoogleSheets(): string {
+    return Array.from(this.songs.values()).map((song) => `=HYPERLINK("${song.url}"; "${song.title}")`).join("\n")
+  }
+
+  toCSV(): string {
+    const header = "Title,Author,URL,User\n";
+
+    return header + Array.from(this.songs.values()).map((song) => {
+      return `${this.correctCSVField(song.title)},${this.correctCSVField(song.author)},${this.correctCSVField(song.url)},${this.correctCSVField(this.getUsername(song.user))}`;
+    }).join("\n")
+  }
+
+  download() {
+    switch (Number(this.selectedFormat)) {
+      case ExportFormat.CSV: 
+        this.dyanmicDownloadByHtmlTag({
+          fileName: this.constitution.name + ".csv",
+          text: this.toCSV()
+        })
+        break;
+      case ExportFormat.GOOGLE_SHEETS:
+        this.dyanmicDownloadByHtmlTag({
+          fileName: this.constitution.name + ".txt",
+          text: this.toGoogleSheets()
+        })
+        break;
+    }
+  }
+
+  private dyanmicDownloadByHtmlTag(arg: {
+    fileName: string,
+    text: string
+  }) {
+    if (!this.setting.element.dynamicDownload) {
+      this.setting.element.dynamicDownload = document.createElement('a');
+    }
+    const element = this.setting.element.dynamicDownload;
+    const fileType = arg.fileName.indexOf('.json') > -1 ? 'text/json' : 'text/plain';
+    element.setAttribute('href', `data:${fileType};charset=utf-8,${encodeURIComponent(arg.text)}`);
+    element.setAttribute('download', arg.fileName);
+
+    var event = new MouseEvent("click");
+    element.dispatchEvent(event);
   }
 
 }

--- a/src/app/components/constitution-page/export/export.component.ts
+++ b/src/app/components/constitution-page/export/export.component.ts
@@ -1,22 +1,37 @@
 // Source : https://stackblitz.com/edit/httpsstackoverflowcomquestions51806464how-to-create-and-downloa?file=src%2Fapp%2Fapp.component.ts
 import { Component, Input } from '@angular/core';
-import { Constitution, EMPTY_CONSTITUTION, Song, User } from 'chelys';
+import { Constitution, EMPTY_CONSTITUTION, Role, Song, User } from 'chelys';
+import { AuthService } from 'src/app/services/auth.service';
+import { compareSongASC } from 'src/app/types/song';
 
-enum ExportFormat {
-  NO_FORMAT,
-  CSV,
-  GOOGLE_SHEETS,
-  
+type ExportFormat = {
+  format: ExportValue;
+  name: string;
+  isDev: boolean;
 }
 
-const FORMATS = [
+enum ExportValue {
+  NO_FORMAT,
+  CSV,
+  CSV_DEV,
+  GOOGLE_SHEETS,
+}
+
+const FORMATS: ExportFormat[] = [
   {
-    format: ExportFormat.CSV,
-    name: 'CSV'
+    format: ExportValue.CSV,
+    name: 'CSV',
+    isDev: false
   },
   {
-    format: ExportFormat.GOOGLE_SHEETS,
-    name: 'Google Sheets'
+    format: ExportValue.CSV_DEV,
+    name: 'CSV (dev)',
+    isDev: true
+  },
+  {
+    format: ExportValue.GOOGLE_SHEETS,
+    name: 'Google Sheets',
+    isDev: false
   }
 ]
 
@@ -31,8 +46,8 @@ export class ExportComponent {
   @Input() users: Map<string, User> = new Map();
 	@Input() songs: Map<number, Song> = new Map();
 
-  availableFormat = FORMATS;
-  selectedFormat: ExportFormat;
+  availableFormat: ExportFormat[];
+  selectedFormat: ExportValue;
 
   private setting = {
     element: {
@@ -40,8 +55,13 @@ export class ExportComponent {
     }
   }
 
-  constructor() {
-    this.selectedFormat = ExportFormat.NO_FORMAT;
+  constructor(private auth: AuthService) {
+    this.selectedFormat = ExportValue.NO_FORMAT;
+
+    if (!this.auth.user.roles.includes(Role.DEV)) {
+      this.availableFormat = FORMATS.filter((f) => !f.isDev);
+    } else this.availableFormat = FORMATS;
+
   }
 
   getUsername(uid: string): string {
@@ -52,30 +72,39 @@ export class ExportComponent {
     return field.includes(',') ? `"${field}"` : field;
   }
 
-  toGoogleSheets(): string {
-    return Array.from(this.songs.values()).map((song) => `=HYPERLINK("${song.url}"; "${song.title}")`).join("\n")
+  toGoogleSheets(songs: Song[]): string {
+    return songs.map((song) => `=HYPERLINK("${song.url}"; "${song.title}")`).join("\n")
   }
 
-  toCSV(): string {
-    const header = "Title,Author,URL,User\n";
-
-    return header + Array.from(this.songs.values()).map((song) => {
-      return `${this.correctCSVField(song.title)},${this.correctCSVField(song.author)},${this.correctCSVField(song.url)},${this.correctCSVField(this.getUsername(song.user))}`;
-    }).join("\n")
+  toCSV(songs: Song[], devFormat: boolean): string {
+    if (devFormat) {
+      return Object.keys(songs[0]).sort().join(",") + "\n" + songs.map((song) => {
+        return Object.entries(song)
+          .sort()
+          .map((v) => this.correctCSVField(String(v[1])))
+          .join(",")
+      }).join("\n");
+    } else {
+      return "author,title,url,user\n" + songs.map((song) => {
+        return `${this.correctCSVField(song.author)},${this.correctCSVField(song.title)},${this.correctCSVField(song.url)},${this.correctCSVField(this.getUsername(song.user))}`;
+      }).join("\n")
+    }
   }
 
   download() {
+    const songs = Array.from(this.songs.values()).sort(compareSongASC);
     switch (Number(this.selectedFormat)) {
-      case ExportFormat.CSV: 
+      case ExportValue.CSV:
+      case ExportValue.CSV_DEV:
         this.dyanmicDownloadByHtmlTag({
           fileName: this.constitution.name + ".csv",
-          text: this.toCSV()
+          text: this.toCSV(songs, Number(this.selectedFormat) === ExportValue.CSV_DEV)
         })
         break;
-      case ExportFormat.GOOGLE_SHEETS:
+      case ExportValue.GOOGLE_SHEETS:
         this.dyanmicDownloadByHtmlTag({
           fileName: this.constitution.name + ".txt",
-          text: this.toGoogleSheets()
+          text: this.toGoogleSheets(songs)
         })
         break;
     }

--- a/src/app/components/constitution-page/owner/owner.component.html
+++ b/src/app/components/constitution-page/owner/owner.component.html
@@ -1,4 +1,4 @@
-<div >
+<div>
   <h1 class="title"> INFORMATIONS </h1>
   <span class="custom-br"> </span>
   <br>


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Onglet `EXPORT` est désormais disponible dans une constitution. Il est alors possible de télécharger les informations des chansons sous plusieurs formats (Google Sheet / CSV).

### :tada: Quality of life
* Un format spécial de CSV est disponible pour les personnes ayant le rôle `Dev`.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie