### PR TITLE
Rappel d'une sous-section d'une constitution

### DIFF
--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -1,19 +1,19 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { ActivatedRoute} from '@angular/router';
+import { ActivatedRoute, Router} from '@angular/router';
 import { canModifySongs, Constitution, createMessage, CstReqGet, CstResUpdate, CstSongReqGetAll, CstSongResUpdate, EMPTY_CONSTITUTION, EventType, extractMessageData, Message, OWNER_INDEX, Role, Song, User, UsrReqGet, UsrReqUnsubscribe, UsrResUpdate, CstFavResUpdate, CstFavReqGet, UserFavorites, CstSongReqUnsubscribe, CstFavReqUnsubscribe, FAVORITES_MAX_LENGTH } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { ManageSongsComponent } from './manage-songs/manage-songs.component';
 import { RandomSongComponent } from './random-song/random-song.component';
 
 enum ConstitutionSection {
-	SONG_LIST,
-	VOTES,
-	OWNER,
-	RESULTS,
-	EXPORT,
-	PARAMETERS
+	SONG_LIST = "songList",
+	VOTES = "votes",
+	OWNER = "owner",
+	RESULTS = "results",
+	EXPORT = "export",
+	PARAMETERS = "parameters"
 }
 
 @Component({
@@ -33,6 +33,7 @@ export class ConstitutionComponent implements OnDestroy {
 	constructor(
 		private auth: AuthService,
 		private route: ActivatedRoute,
+		private router: Router,
 		private dialog: MatDialog,
 	) {
 		this.cstID = "";
@@ -68,6 +69,7 @@ export class ConstitutionComponent implements OnDestroy {
 	private onConnect(): void {
 		this.route.params.subscribe((params) => {
 			this.cstID = params.cstID;
+			this.setCurrentSection(params.section)
 
 			const getCSTMessage = createMessage<CstReqGet>(EventType.CST_get, { ids: [this.cstID] })
 			this.auth.ws.send(getCSTMessage);
@@ -153,6 +155,7 @@ export class ConstitutionComponent implements OnDestroy {
 
 	setCurrentSection(newSection: ConstitutionSection): void {
 		this.currentSection = newSection;
+		this.router.navigate(['constitution', this.cstID, this.currentSection])
 	}
 
 	isSectionActive(section: ConstitutionSection): boolean {

--- a/src/app/components/constitution-page/results/results-grade/results-grade.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/results-grade.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnDestroy } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { Constitution, createMessage, EMPTY_CONSTITUTION, EventType, extractMessageData, GradeReqGetAll, GradeReqUnsubscribe, GradeResUserDataUpdate, Message, Song, User, UserFavorites } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
@@ -42,8 +41,7 @@ export class ResultsGradeComponent implements OnDestroy {
 
   constructor(
     private auth: AuthService,
-    private route: ActivatedRoute,
-    private dialog: MatDialog
+    private route: ActivatedRoute
   ) {
     this.auth.pushAuthFunction(this.onConnect, this);
 		this.auth.pushEventHandler(this.handleEvents, this);

--- a/src/app/components/current-constitution-page/current-constitution-page.component.html
+++ b/src/app/components/current-constitution-page/current-constitution-page.component.html
@@ -40,8 +40,8 @@
 				{{ displayData.constitution.users.length}} / {{ displayData.constitution.maxUserCount}}
 			</td>
 			<td [ngSwitch]="getStatus(displayData.constitution)">
-				<button mat-raised-button color="primary" *ngSwitchCase="'JOINED'" [routerLink]="['/constitution/', displayData.constitution.id]">Voir</button>
-				<button mat-raised-button color="primary" *ngSwitchCase="'JOINABLE'" (click)="joinConstitution(displayData)" [routerLink]="['/constitution/', displayData.constitution.id]">Rejoindre</button>
+				<button mat-raised-button color="primary" *ngSwitchCase="'JOINED'" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">Voir</button>
+				<button mat-raised-button color="primary" *ngSwitchCase="'JOINABLE'" (click)="joinConstitution(displayData)" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">Rejoindre</button>
 				<span *ngSwitchCase="'FULL'">Complet</span>
 			</td>
 		</tr>

--- a/src/app/components/join-constitution/join-constitution.component.ts
+++ b/src/app/components/join-constitution/join-constitution.component.ts
@@ -39,7 +39,7 @@ export class JoinConstitutionComponent {
       const data = extractMessageData<CstResJoin>(message).status;
       if (data.success) {
         this.errorStatus.clearStatus();
-        this.router.navigateByUrl(`/constitution/${this.joinForm.get('id')?.value}`);
+        this.router.navigateByUrl(`/constitution/${this.joinForm.get('id')?.value}/songList`);
         this.closeWindow()
       } else {
         switch (data.status) {

--- a/src/app/types/routes.ts
+++ b/src/app/types/routes.ts
@@ -7,10 +7,10 @@ import { ProfilePageComponent } from "../components/profile-page/profile-page.co
 import { UsersPageComponent } from "../components/users-page/users-page.component";
 
 export const ROUTES: Routes = [
-	{ path: '', 											component: HomePageComponent },
-	{ path: 'admin-page', 						component: AdminPageComponent },
-	{ path: 'constitution/:cstID', 		component: ConstitutionComponent},
-	{ path: 'current-constitutions', 	component: CurrentConstitutionPageComponent },
-	{ path: 'profile', 								component: ProfilePageComponent },
-	{ path: 'users', 									component: UsersPageComponent },
+	{ path: '', 																component: HomePageComponent },
+	{ path: 'admin-page', 											component: AdminPageComponent },
+	{ path: 'constitution/:cstID/:section', 		component: ConstitutionComponent},
+	{ path: 'current-constitutions', 						component: CurrentConstitutionPageComponent },
+	{ path: 'profile', 													component: ProfilePageComponent },
+	{ path: 'users', 														component: UsersPageComponent },
 ]


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* Rafraîchir la page d'une constitution va maintenant se rappeler de la sous-section.

### :hammer_and_wrench: Refactoring
* L'enum `ConstitutionSection` utilise désormais des strings au lieu de number.
* L'URL d'une page de constitution prend un paramètre supplémentaire et est désormais sous la forme suivante : `constitution/:cstID/:section`.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie