### PR TITLE
Ajout du support pour la suppression de constitution.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@types/lodash": "^4.14.171",
 				"@types/url-parse": "^1.4.4",
 				"canvas-confetti": "^1.4.0",
-				"chelys": "^2.5.0",
+				"chelys": "^2.6.0",
 				"echarts": "^5.2.1",
 				"firebase": "^7.0 || ^8.0",
 				"lodash": "^4.17.21",
@@ -3869,9 +3869,10 @@
 			}
 		},
 		"node_modules/archiver/node_modules/async": {
-			"version": "3.2.0",
-			"dev": true,
-			"license": "MIT"
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+			"dev": true
 		},
 		"node_modules/are-we-there-yet": {
 			"version": "1.1.5",
@@ -4077,9 +4078,10 @@
 			"license": "ISC"
 		},
 		"node_modules/async": {
-			"version": "2.6.3",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"lodash": "^4.17.14"
 			}
@@ -5002,9 +5004,9 @@
 			"license": "MIT"
 		},
 		"node_modules/chelys": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.5.0.tgz",
-			"integrity": "sha512-d1JQWkBx4Xv/5M1Zg2ua+flWgA94elzC77eFJ38h3VlNNoDS6EFtVn5Kx3pasVdXs+uvxTVpBIPYjU80JKzgHA=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.6.0.tgz",
+			"integrity": "sha512-xWI+mxoiGtFcmuUoQ4nolQBtMpAlXhLivLxsegmnOwF0mzGN+SpdlnkaigreOcE2IIKeYgLFGq4QCIt76hZ5VA=="
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
@@ -20613,9 +20615,10 @@
 			}
 		},
 		"node_modules/winston/node_modules/async": {
-			"version": "3.2.0",
-			"dev": true,
-			"license": "MIT"
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+			"dev": true
 		},
 		"node_modules/winston/node_modules/is-stream": {
 			"version": "2.0.0",
@@ -23383,7 +23386,9 @@
 			},
 			"dependencies": {
 				"async": {
-					"version": "3.2.0",
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
 					"dev": true
 				}
 			}
@@ -23583,7 +23588,9 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.3",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.14"
@@ -24215,9 +24222,9 @@
 			"dev": true
 		},
 		"chelys": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.5.0.tgz",
-			"integrity": "sha512-d1JQWkBx4Xv/5M1Zg2ua+flWgA94elzC77eFJ38h3VlNNoDS6EFtVn5Kx3pasVdXs+uvxTVpBIPYjU80JKzgHA=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/chelys/-/chelys-2.6.0.tgz",
+			"integrity": "sha512-xWI+mxoiGtFcmuUoQ4nolQBtMpAlXhLivLxsegmnOwF0mzGN+SpdlnkaigreOcE2IIKeYgLFGq4QCIt76hZ5VA=="
 		},
 		"chokidar": {
 			"version": "3.5.2",
@@ -35129,7 +35136,9 @@
 			},
 			"dependencies": {
 				"async": {
-					"version": "3.2.0",
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
 					"dev": true
 				},
 				"is-stream": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@types/lodash": "^4.14.171",
 		"@types/url-parse": "^1.4.4",
 		"canvas-confetti": "^1.4.0",
-		"chelys": "^2.5.0",
+		"chelys": "^2.6.0",
 		"echarts": "^5.2.1",
 		"firebase": "^7.0 || ^8.0",
 		"lodash": "^4.17.21",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -73,6 +73,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatExpansionModule } from "@angular/material/expansion";
 import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatMenuModule} from '@angular/material/menu';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 // MDB
 import { MdbDropdownModule } from 'mdb-angular-ui-kit/dropdown';
@@ -125,7 +126,7 @@ import { AuthService } from './services/auth.service';
 		HeatmapComponent,
 	 	ChordComponent,
 	 	ManageInvitesComponent,
-   ManageRolesComponent
+    ManageRolesComponent
 	],
 	imports: [
 		BrowserModule,
@@ -152,6 +153,7 @@ import { AuthService } from './services/auth.service';
 		MatDialogModule,
 		MatExpansionModule,
 		MatProgressBarModule,
+		MatSnackBarModule,
 		MdbDropdownModule,
 		MdbCollapseModule
 	],

--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -1,7 +1,8 @@
 
 import { Component, OnDestroy } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar'
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { ActivatedRoute} from '@angular/router';
+import { ActivatedRoute, Router} from '@angular/router';
 import { canModifySongs, Constitution, createMessage, CstReqGet, CstResUpdate, CstSongReqGetAll, CstSongResUpdate, EMPTY_CONSTITUTION, EventType, extractMessageData, Message, OWNER_INDEX, Role, Song, User, UsrReqGet, UsrReqUnsubscribe, UsrResUpdate, CstFavResUpdate, CstFavReqGet, UserFavorites, CstSongReqUnsubscribe, CstFavReqUnsubscribe, FAVORITES_MAX_LENGTH } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { ManageSongsComponent } from './manage-songs/manage-songs.component';
@@ -33,7 +34,9 @@ export class ConstitutionComponent implements OnDestroy {
 	constructor(
 		private auth: AuthService,
 		private route: ActivatedRoute,
+		private router: Router,
 		private dialog: MatDialog,
+		private _snackBar: MatSnackBar
 	) {
 		this.cstID = "";
 		this.constitution = EMPTY_CONSTITUTION;
@@ -113,8 +116,19 @@ export class ConstitutionComponent implements OnDestroy {
 				const favorites = extractMessageData<CstFavResUpdate>(message).userFavorites;
 				this.favorites.set(favorites.uid, favorites);
 			} break;
+
+			case EventType.CST_delete: {
+				this.router.navigateByUrl('current-constitutions');
+				this.openSnackBar(`La constitution ${this.constitution.name} a été supprimée`, 'OK');
+			} break;
 		}
 	}
+
+	openSnackBar(message: string, action: string) {
+    this._snackBar.open(message, action, {
+			horizontalPosition: 'right'
+		});
+  }
 
 	private songUpdate(response: CstSongResUpdate) {
 		const songInfo = response.songInfo;

--- a/src/app/components/constitution-page/owner/owner.component.html
+++ b/src/app/components/constitution-page/owner/owner.component.html
@@ -40,7 +40,7 @@
     <mat-expansion-panel-header> 
         <mat-panel-title> Danger Zone </mat-panel-title>
     </mat-expansion-panel-header>
-    <mat-slide-toggle [checked]="security" (change)="updateSecurity()"> Retirer la sécurité </mat-slide-toggle>
+    <mat-slide-toggle [checked]="security" (change)="updateSecurity()"> Garder la sécurité </mat-slide-toggle>
     <br> <br>
     <button mat-raised-button [disabled]="security" color="warn" (click)="deleteConstitution()"> Supprimer la constitution </button>
   </mat-expansion-panel>

--- a/src/app/components/constitution-page/owner/owner.component.html
+++ b/src/app/components/constitution-page/owner/owner.component.html
@@ -36,7 +36,15 @@
       </form>
       <button mat-raised-button color="primary" (click)="updateNameURL()"> Mettre à jour </button>
     </mat-expansion-panel>
-  </mat-accordion>
+  <mat-expansion-panel [expanded]="true">
+    <mat-expansion-panel-header> 
+        <mat-panel-title> Danger Zone </mat-panel-title>
+    </mat-expansion-panel-header>
+    <mat-slide-toggle [checked]="security" (change)="updateSecurity()"> Retirer la sécurité </mat-slide-toggle>
+    <br> <br>
+    <button mat-raised-button [disabled]="security" color="warn" (click)="deleteConstitution()"> Supprimer la constitution </button>
+  </mat-expansion-panel>
+</mat-accordion>
   <br>
   <h1 class="title"> TYPE </h1>
   <span class="custom-br"> </span>

--- a/src/app/components/constitution-page/owner/owner.component.ts
+++ b/src/app/components/constitution-page/owner/owner.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Constitution, ConstitutionType, createMessage, CstReqNameURL, EMPTY_CONSTITUTION, EventType, Song, User } from 'chelys';
+import { Constitution, ConstitutionType, createMessage, CstReqDelete, CstReqNameURL, EMPTY_CONSTITUTION, EventType, Song, User } from 'chelys';
 import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
 
@@ -15,6 +15,7 @@ export class OwnerComponent implements OnChanges {
 	@Input() users: Map<string, User> = new Map();
 	@Input() songs: Map<number, Song> = new Map();
 
+	public security: boolean;
 	public constitutionParameterForm: FormGroup;
 
 	// HTML can't access the ConstiutionType enum directly
@@ -34,6 +35,7 @@ export class OwnerComponent implements OnChanges {
 			name: [this.constitution.name, Validators.required], 
 			playlistLink: [this.constitution.playlistLink],
 		});
+		this.security = true;
 	}
 
 	numberOfSongs(): number {
@@ -63,6 +65,14 @@ export class OwnerComponent implements OnChanges {
 		});
 
 		this.auth.ws.send(message);
+	}
+
+	updateSecurity(): void {
+		this.security = !this.security;
+	}
+
+	deleteConstitution(): void {
+		this.auth.ws.send(createMessage<CstReqDelete>(EventType.CST_delete, { id: this.constitution.id }));
 	}
 
 }


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Le président d'une constitution peut désormais la faire supprimer.
* Passage à Chelys 2.6.0.

### :tada: Quality of life
* Tous les utilisateurs sur la constitution supprimée sont redirigé vers la page des constitutions en cours avec un message en bas à droite.
* Le président doit d'abord désactiver un verrou avant de pouvoir supprimer la constitution.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

Équivalent Kalimba : https://github.com/TableauBits/Kalimba/pull/32

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie