### PR TITLE
Ajout de plus d'informations sur la page des résultats d'une grade constitution

### DIFF
--- a/src/app/components/constitution-page/results/results-favorites/results-favorites.component.html
+++ b/src/app/components/constitution-page/results/results-favorites/results-favorites.component.html
@@ -33,6 +33,39 @@
   </mat-expansion-panel>
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header> 
+        <mat-panel-title> Favoris des participants </mat-panel-title>
+    </mat-expansion-panel-header>
+    Favoris de :
+    <mat-form-field appearance="fill">
+      <mat-label> Choisir un utilisateur </mat-label>
+      <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
+        <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <img class="picture image-de" [src]="getSelectedUser().photoURL" matTooltip="{{getSelectedUser().displayName}}">
+    <br>
+    <br>
+    <table id="t01">
+      <tr>
+        <th style="width: 15%;"> Index </th>
+        <th style="width: 50%;"> Titre - Auteur </th>
+        <th style="width: 15%;"> URL </th>
+        <th style="width: 20%;"> Ajouté par </th>
+      </tr>
+      <tr *ngFor="let fav of getSelectedUserFavorites();let indexOfelement=index;">
+        <td> {{ indexOfelement + 1 }} </td>
+        <td> {{fav.title}} - {{fav.author}} </td>
+        <td>          
+          <a href="{{fav.url}}" target="_blank">
+            <mat-icon>play_circle_outline</mat-icon>
+          </a> 
+        </td>
+        <td> <img class="picture avatar" [src]="getUser(fav.user).photoURL" matTooltip="{{ getUser(fav.user).displayName }}"> </td>
+      </tr>
+    </table>
+  </mat-expansion-panel>
+  <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel-header> 
         <mat-panel-title> Favoris entre les participants </mat-panel-title>
     </mat-expansion-panel-header>
     Résumé des favoris de :

--- a/src/app/components/constitution-page/results/results-favorites/results-favorites.component.ts
+++ b/src/app/components/constitution-page/results/results-favorites/results-favorites.component.ts
@@ -100,6 +100,13 @@ export class ResultsFavoritesComponent implements OnChanges {
     return this.users.get(this.selectedUser) || EMPTY_USER;
   }
 
+  getSelectedUserFavorites(): Song[] {
+    const favIds = this.favorites.get(this.selectedUser);
+    if (isNil(favIds)) return [];
+
+    return favIds.favs.map((id) => this.songs.get(id) || EMPTY_SONG);
+  }
+
   newSelection(): void  {
     this.generatePieData();
   }

--- a/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.html
@@ -14,7 +14,7 @@
     <br>
     <br>
     <table id="t01">
-      <tr >
+      <tr>
         <th *ngFor="let user of getUserList()"> <img class="picture" [src]="getUser(user.uid).photoURL"> {{user.displayName}} </th>
       </tr>
       <tr>
@@ -42,5 +42,39 @@
     <br>
     Variance : {{selectedUserVar.toFixed(3)}}
     <app-histogram [values]="histogramValues"> </app-histogram>
+  </mat-expansion-panel>
+  <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel-header> 
+        <mat-panel-title> Notes des participants </mat-panel-title>
+    </mat-expansion-panel-header>
+    Notes de : 
+    <mat-form-field appearance="fill">
+      <mat-label> Choisir un utilisateur </mat-label>
+      <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
+        <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <img class="image-de picture3" [src]="getSelectedUser().photoURL" matTooltip="{{getSelectedUser().displayName}}">
+    <br>
+    <table id="t01">
+      <tr>
+        <th> Titre - Utilisateur </th>
+        <th> URL </th>
+        <th> Ajouté par </th>
+        <th> Note </th>
+      </tr>
+      <tr *ngFor="let song of getSelectedUserSong()">
+        <td> {{song.song.title}} - {{song.song.author}} </td>
+        <td>
+          <a href="{{song.song.url}}" target="_blank">
+            <mat-icon>play_circle_outline</mat-icon>
+          </a>
+        </td>
+        <td>
+          <img class="picture avatar" [src]="getUser(song.song.user).photoURL" matTooltip="{{ getUser(song.song.user).displayName }}">
+        </td>
+        <td> {{song.grade}}</td>
+      </tr>
+    </table>
   </mat-expansion-panel>
 </mat-accordion>

--- a/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.ts
@@ -3,7 +3,7 @@ import { EMPTY_SONG, EMPTY_USER, Song, SongPlatform, User } from 'chelys';
 import { isNil, toNumber } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
 import { mean, variance } from 'src/app/types/math';
-import { UserGradeResults } from 'src/app/types/results';
+import { SongGrade, UserGradeResults } from 'src/app/types/results';
 import { compareSongDSC } from 'src/app/types/song';
 import { getIDFromURL } from 'src/app/types/url';
 
@@ -68,6 +68,20 @@ export class GradeGradesComponent {
 
   getSelectedUser(): User {
     return this.users.get(this.selectedUser) || EMPTY_USER;
+  }
+
+  getSelectedUserSong(): SongGrade[] {
+    const userResult = this.userResults.get(this.selectedUser);
+    if (isNil(userResult)) return [];
+    let songs: SongGrade[] = [];
+    userResult.data.values.forEach((value, key) => {
+      songs.push({
+        song: this.songs.get(key) || EMPTY_SONG,
+        grade: value
+      })
+    });
+   
+    return songs.sort((a, b) => b.grade - a.grade);
   }
 
   getUserList(): User[] {

--- a/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.html
@@ -1,9 +1,66 @@
-<br>
-Moyenne : {{result.mean.toFixed(3)}}
-<br>
-Variance : {{result.var.toFixed(3)}}
-<br>
-<br>
-Répartition des notes :
-<app-histogram [values]="histogramValues"> </app-histogram>
+<mat-accordion multi class="panel">
+  <mat-expansion-panel [expanded]="true">
+    <mat-expansion-panel-header> 
+        <mat-panel-title> Répartition des notes </mat-panel-title>
+    </mat-expansion-panel-header>
+    <br>
+    Moyenne : {{result.mean.toFixed(3)}}
+    <br>
+    Variance : {{result.var.toFixed(3)}}
+    <br>
+    <br>
+    Répartition des notes :
+    <app-histogram [values]="histogramValues"> </app-histogram>
+  </mat-expansion-panel>
+  <mat-expansion-panel [expanded]="true">
+    <mat-expansion-panel-header> 
+        <mat-panel-title> Favoris </mat-panel-title>
+    </mat-expansion-panel-header>
+    <table id="t01">
+      <tr>
+        <th style="width: 15%;"> Index </th>
+        <th style="width: 50%;"> Titre - Auteur </th>
+        <th style="width: 15%;"> URL </th>
+        <th style="width: 20%;"> Ajouté par </th>
+      </tr>
+      <tr *ngFor="let fav of getSelectedUserFavorites();let indexOfelement=index;">
+        <td> {{ indexOfelement + 1 }} </td>
+        <td> {{fav.title}} - {{fav.author}} </td>
+        <td>          
+          <a href="{{fav.url}}" target="_blank">
+            <mat-icon>play_circle_outline</mat-icon>
+          </a> 
+        </td>
+        <td> <img class="picture avatar" [src]="getUser(fav.user).photoURL" matTooltip="{{ getUser(fav.user).displayName }}"> </td>
+      </tr>
+    </table>
+  </mat-expansion-panel>
+  <mat-expansion-panel [expanded]="true">
+    <mat-expansion-panel-header> 
+        <mat-panel-title> Notes </mat-panel-title>
+    </mat-expansion-panel-header>
+    <table id="t01">
+      <tr>
+        <th> Titre - Utilisateur </th>
+        <th> URL </th>
+        <th> Ajouté par </th>
+        <th> Note </th>
+      </tr>
+      <tr *ngFor="let song of getSelectedUserSong()">
+        <td> {{song.song.title}} - {{song.song.author}} </td>
+        <td>
+          <a href="{{song.song.url}}" target="_blank">
+            <mat-icon>play_circle_outline</mat-icon>
+          </a>
+        </td>
+        <td>
+          <img class="picture avatar" [src]="getUser(song.song.user).photoURL" matTooltip="{{ getUser(song.song.user).displayName }}">
+        </td>
+        <td> {{song.grade}}</td>
+      </tr>
+    </table>
+  </mat-expansion-panel>
+</mat-accordion>
+
+
 

--- a/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.scss
+++ b/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.scss
@@ -1,0 +1,34 @@
+@import "../../../../../../styles/variables.scss";
+
+table {
+	margin-left: auto;
+	margin-right: auto;
+	width: 95%;
+	overflow-x: auto;
+	font-size:medium;
+}
+
+td, th {
+	border: 1px solid $sasuke;
+	text-align: center;
+	padding: 8px;
+}
+
+#t01 th {
+	background-color: $mineshaft;
+	color: whitesmoke;
+}
+
+#t01 tr:nth-child(even) {
+	background-color: $sasuke;
+}
+#t01 tr:nth-child(odd) {
+	background-color: $cape-cod;
+}
+
+.picture {
+  width: 55px;
+  height: 55px;
+  -moz-border-radius: 28px;
+  border-radius: 28px;
+}

--- a/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { EMPTY_USER_GRADE_RESULTS, UserGradeResults } from 'src/app/types/results';
+import { EMPTY_SONG, EMPTY_USER, Song, User, UserFavorites } from 'chelys';
+import { isNil } from 'lodash';
+import { AuthService } from 'src/app/services/auth.service';
+import { EMPTY_USER_GRADE_RESULTS, SongGrade, UserGradeResults } from 'src/app/types/results';
 
 @Component({
   selector: 'app-grade-profile',
@@ -9,6 +12,9 @@ import { EMPTY_USER_GRADE_RESULTS, UserGradeResults } from 'src/app/types/result
 export class GradeProfileComponent implements OnChanges {
 
   @Input() result: UserGradeResults = EMPTY_USER_GRADE_RESULTS;
+  @Input() users: Map<string, User> = new Map();
+	@Input() songs: Map<number, Song> = new Map();
+  @Input() favorites: Map<string, UserFavorites> = new Map();
 
   histogramValues: number[] = []
 
@@ -16,6 +22,30 @@ export class GradeProfileComponent implements OnChanges {
     this.histogramValues = Array.from(changes['result'].currentValue.data.values.values());
   }
 
-  constructor() { }
+  constructor(private auth: AuthService) { }
 
+  getUser(uid: string): User {
+    return this.users.get(uid) || EMPTY_USER;
+  }
+
+  getSelectedUserFavorites(): Song[] {
+    const favIds = this.favorites.get(this.auth.uid);
+    if (isNil(favIds)) return [];
+
+    return favIds.favs.map((id) => this.songs.get(id) || EMPTY_SONG);
+  }
+
+  getSelectedUserSong(): SongGrade[] {
+    const userResult = this.result;
+    if (isNil(userResult)) return [];
+    let songs: SongGrade[] = [];
+    userResult.data.values.forEach((value, key) => {
+      songs.push({
+        song: this.songs.get(key) || EMPTY_SONG,
+        grade: value
+      })
+    });
+   
+    return songs.sort((a, b) => b.grade - a.grade);
+  }
 }

--- a/src/app/components/constitution-page/results/results-grade/results-grade.component.html
+++ b/src/app/components/constitution-page/results/results-grade/results-grade.component.html
@@ -53,23 +53,28 @@
 	<br>
 	<div [ngSwitch]="currentSection">
 		<app-grade-ranking *ngSwitchCase="gradeResultSection.RANKING"
-			[users]="users" [songs]="songs" [songResults]="songResults"> </app-grade-ranking>
+			[users]="users" [songs]="songs" [songResults]="songResults">
+		</app-grade-ranking>
 		<app-grade-grades *ngSwitchCase="gradeResultSection.GRADES"
-			[users]="users" [songs]="songs" [userResults]="userResults"> </app-grade-grades>
+			[users]="users" [songs]="songs" [userResults]="userResults">
+		</app-grade-grades>
 		<app-grade-average *ngSwitchCase="gradeResultSection.AVERAGE"
-			[users]="users" [userResults]="userResults" [songs]="songs" [numberOfSongsByUser]="constitution.numberOfSongsPerUser"> </app-grade-average>
+			[users]="users" [userResults]="userResults" [songs]="songs" [numberOfSongsByUser]="constitution.numberOfSongsPerUser">
+		</app-grade-average>
 		<app-grade-ranks *ngSwitchCase="gradeResultSection.RANKS"
-			[users]="users" [songs]="songs" [songResults]="songResults"> </app-grade-ranks>
+			[users]="users" [songs]="songs" [songResults]="songResults">
+		</app-grade-ranks>
 		<app-results-favorites *ngSwitchCase="gradeResultSection.FAVORITES"
-			[users]="users" [songs]="songs" [favorites]="favorites"></app-results-favorites>
+			[users]="users" [songs]="songs" [favorites]="favorites">
+		</app-results-favorites>
 		<app-grade-profile *ngSwitchCase="gradeResultSection.PROFIL"
-			[result]="getAuthResult()"> </app-grade-profile>
+			[users]="users" [songs]="songs" [favorites]="favorites" [result]="getAuthResult()">
+		</app-grade-profile>
 		<app-grade-electoral *ngSwitchCase="gradeResultSection.ELECTORAL"
 			[users]="users" [songs]="songs" [favorites]="favorites" [songResults]="songResults" [userResults]="userResults">
 		</app-grade-electoral> 
 		<app-grade-relationship *ngSwitchCase="gradeResultSection.RELATIONSHIP"
-		[users]="users" [songs]="songs" [favorites]="favorites" [songResults]="songResults" [userResults]="userResults">
-
+			[users]="users" [songs]="songs" [favorites]="favorites" [songResults]="songResults" [userResults]="userResults">
 		</app-grade-relationship>
 	</div>
 </ng-template>

--- a/src/app/types/results.ts
+++ b/src/app/types/results.ts
@@ -1,4 +1,4 @@
-import { GradeUserData } from "chelys";
+import { GradeUserData, Song } from "chelys";
 import { mean, normalize, variance } from "./math";
 
 export interface UserGradeResults {
@@ -18,6 +18,11 @@ export const EMPTY_USER_GRADE_RESULTS: UserGradeResults = {
 export interface SongGradeResult {
   id: number;
   score: number;
+}
+
+export interface SongGrade {
+  song: Song;
+  grade: number;
 }
 
 export function generateUserGradeResults(data: GradeUserData): UserGradeResults {


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout d'une nouvelle table "Notes des participants" permettant de voir le détail des notes d'un participant en particulier.
* Ajout d'une nouvelle table "Favoris des participants" permettant de voir le détail des favoris d'un participant en particulier.

### :tada: Quality of life
* Revision de la sous-section Profile de la page des résultats. En plus de la répartition des notes, de la moyenne et la variance maintenant sont ajouté les notes (rangé en ordre décroissant) et les favoris de l'utilisateur.

### :hammer_and_wrench: Refactoring
* Ajout du type `SongGrade`.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie