### PR TITLE
Migration vers Fly.io

### DIFF
--- a/src/app/components/invite-page/invite-page.component.ts
+++ b/src/app/components/invite-page/invite-page.component.ts
@@ -26,7 +26,7 @@ export class InvitePageComponent {
   public HTTPconnectionURL: string;
 
   constructor(
-    public fb: FormBuilder, 
+    public fb: FormBuilder,
     private http: HttpClient,
     private fireAuth: AngularFireAuth,
     public auth: AuthService
@@ -35,14 +35,11 @@ export class InvitePageComponent {
       inviteID: [, Validators.required]
     });
     this.hasReceivedGETResponse = false;
-    this.inviteGETResponse = {isValid: false, inviter: EMPTY_USER};
+    this.inviteGETResponse = { isValid: false, inviter: EMPTY_USER };
     this.hasReceivedPOSTResponse = false;
-    this.invitePOSTResponse = {response: {success: false, status: ""}};
+    this.invitePOSTResponse = { response: { success: false, status: "" } };
 
-    this.HTTPconnectionURL = `${environment.protocolHTTP}${environment.serverAPI}`;
-    if (!environment.production) {
-      this.HTTPconnectionURL += `:${environment.portWebSocket}`;
-    }
+    this.HTTPconnectionURL = `${environment.protocolHTTP}${environment.serverAPI}:${environment.portWebSocket}`;
   }
 
   getInviteID(): string {
@@ -63,7 +60,7 @@ export class InvitePageComponent {
 
   async getGoogleCredentials(): Promise<NewAccount> {
     const provider = new firebase.auth.GoogleAuthProvider();
-	const user = (await this.fireAuth.signInWithPopup(provider)).user;
+    const user = (await this.fireAuth.signInWithPopup(provider)).user;
 
     if (isNil(user)) {
       throw new Error("User Google Credentials are nil");
@@ -81,7 +78,7 @@ export class InvitePageComponent {
     try {
       const accountInfo = await this.getGoogleCredentials();
       const inviteID = this.getInviteID();
-      this.http.post(`${this.HTTPconnectionURL}/invite/${inviteID}`, {newAccount: accountInfo}).subscribe((response) => {
+      this.http.post(`${this.HTTPconnectionURL}/invite/${inviteID}`, { newAccount: accountInfo }).subscribe((response) => {
         console.log(response)
         this.hasReceivedPOSTResponse = true;
         this.invitePOSTResponse = response as InvResPOST;
@@ -100,7 +97,7 @@ export class InvitePageComponent {
       const success = "Votre compte Matbay a été créé";
       const error = `Une erreur est survenue: ${this.invitePOSTResponse.response.status}`;
 
-      return this.invitePOSTResponse.response.success? success : error;
+      return this.invitePOSTResponse.response.success ? success : error;
     }
 
     return "Votre compte n'a pas encore été créé."

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -46,7 +46,7 @@ function pingWS(ws: WebSocket): void {
 	if (!environment.production) {
 		console.log(lyric);
 	}
-	setTimeout(pingWS, WS_PING_INTERVAL, ws);	
+	setTimeout(pingWS, WS_PING_INTERVAL, ws);
 }
 
 function pingHTTP(http: HttpClient, url: string): void {
@@ -93,14 +93,10 @@ export class AuthService {
 		this.eventHandlers = [[this.updateUserData, this]];
 		this.authCallbacks = [];
 
-		this.WSconnectionURL = `${environment.protocolWebSocket}${environment.serverAPI}`;
-		this.HTTPconnectionURL = `${environment.protocolHTTP}${environment.serverAPI}`;
-		if (!environment.production) {
-			this.WSconnectionURL += `:${environment.portWebSocket}`;
-			this.HTTPconnectionURL += `:${environment.portWebSocket}`;
-			console.warn("Debug mode enabled! Yatga will attempt to connect to: ", this.WSconnectionURL, this.HTTPconnectionURL);
-		}
-		
+		this.WSconnectionURL = `${environment.protocolWebSocket}${environment.serverAPI}:${environment.portWebSocket}`;
+		this.HTTPconnectionURL = `${environment.protocolHTTP}${environment.serverAPI}:${environment.portWebSocket}`;
+		console.warn("Debug mode enabled! Yatga will attempt to connect to: ", this.WSconnectionURL, this.HTTPconnectionURL);
+
 		this.ws = new WebSocket(this.WSconnectionURL)
 		this.ws.onopen = () => {
 			this.fireAuth.authState.subscribe(async user => {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -12,6 +12,6 @@ export const environment = {
 	},
 	protocolHTTP: "https://",
 	protocolWebSocket: "wss://",
-	serverAPI: "matbay-kalimba.herokuapp.com",
-	portWebSocket: "", // in production, we can let ws figure out the port automagically
+	serverAPI: "kalimba.fly.dev",
+	portWebSocket: "3000",
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -17,7 +17,7 @@ export const environment = {
 	protocolHTTP: "http://",
 	protocolWebSocket: "ws://",
 	serverAPI: "localhost",
-	portWebSocket: "3000", // in developpement, we need to give a port, otherwise ws is going to assume 4200 (used by angular)
+	portWebSocket: "3000",
 };
 
 /*


### PR DESCRIPTION
## Description
Cette PR accompagne [la PR équivalente sur Kalimba](https://github.com/TableauBits/Kalimba/pull/38) pour migrer le service vers Fly.io. Pour Yatga, cette migration implique simplement de changer l'URL du serveur dans l'environnement de production

### :rocket: Nouveauté
- L'URL du serveur de Kalimba est maintenant celle de Fly.io

### :hammer_and_wrench: Refactoring
- Reformattage de certains fichiers

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie