### PR TITLE
Correction du bouton Réinitialiser pour le classement dans la Zone Électorale.

### DIFF
--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -122,7 +122,7 @@
                     <mat-icon class="menu-panel">trending_down</mat-icon>
                     <span>Classer par ordre décroissant</span>
                   </button>
-                  <button mat-menu-item class="menu-panel" (click)="setOrderByGrade(2)">
+                  <button mat-menu-item class="menu-panel" (click)="resetOrder()">
                     <mat-icon class="menu-panel">replay</mat-icon>
                     <span>Réinitialiser</span>
                   </button>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -280,6 +280,7 @@ export class VotesGradeComponent implements OnDestroy {
 	resetOrder() {
 		this.setOrderByUser(false);
 		this.setOrderByFavs(false);
+		this.setOrderByGrade(GradeOrder.NONE)
 	}
 
 	// TODO : Implement class ?


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :bug: Bugfix
* Dans la section `Zone Électorale`, il n'était pas possible de ré-initialiser l'ordre des chansons après avoir choisi un classement à partir du bouton `Réinitialiser`.

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie