### PR TITLE
Ajout des releases Github sur la Home Page

### DIFF
--- a/src/app/components/home-page/home-page.component.html
+++ b/src/app/components/home-page/home-page.component.html
@@ -2,28 +2,41 @@
 <div class="title">
   <h1> <b> MATBAY </b> </h1>
   <h2> Le site des constitutions </h2>
+  
   <span class="custom-br"></span>
-  <h3> Travaux en cours. </h3> 
-  <img class="wip" src="assets/wip.gif">
-  <br> <br>
-  <span class="custom-br"></span>
-  <h3> Releases : </h3>
+  <h2> Releases : </h2>
   <mat-accordion multi class="panel">
     <mat-expansion-panel *ngFor="let release of releases">
       <mat-expansion-panel-header>
         <mat-panel-title>
-          {{release.tag_name}}
+          {{release.tag}}
         </mat-panel-title>
         <mat-panel-description>
           <b> {{release.name}} </b>
-          <a href="{{release.html_url}}" target="_blank" matTooltip="Voir depuis Github">
+          <a href="{{release.url}}" target="_blank" matTooltip="Voir depuis Github">
             <mat-icon>link</mat-icon> 
           </a>
         </mat-panel-description>
       </mat-expansion-panel-header>
-      <p>Publié le : {{release.published_at}}</p> <br>
-      <p>{{release.body}}</p>
+      <p class="text">
+        <b> Publié le : </b> {{release.date}} <br> <br>
+        <b> Changements : </b> 
+        <span *ngFor="let change of release.body.changes">
+          <br> * {{change.title}}
+          (<a href="{{change.url}}" target="_blank">
+            {{change.url}}
+          </a>)
+        </span> <br> <br>
+        <b> Changements Complet: </b> <br>
+        <a href="{{release.body.full}}" target="_blank">
+          {{release.body.full}}
+        </a>
+      </p>
     </mat-expansion-panel>
   </mat-accordion>
-  <br> <br> App by TableauBits
+  <br> <br>
+  <span class="custom-br"></span>
+  <h2> Travaux en cours. </h2> 
+  <img class="wip" src="assets/wip.gif">
+  <br> <br> App by TableauBits <br> <br>
 </div>

--- a/src/app/components/home-page/home-page.component.html
+++ b/src/app/components/home-page/home-page.component.html
@@ -1,18 +1,18 @@
 <br>
 <div class="title">
   <h1> <b> MATBAY </b> </h1>
-  <h2> Le site des constitutions </h2>
-  
+  <h2> Le site des Constitutions </h2>
   <span class="custom-br"></span>
   <h2> Releases : </h2>
   <mat-accordion multi class="panel">
-    <mat-expansion-panel *ngFor="let release of releases">
+    <mat-expansion-panel *ngFor="let release of releases; index as i">
       <mat-expansion-panel-header>
         <mat-panel-title>
           {{release.tag}}
         </mat-panel-title>
         <mat-panel-description>
           <b> {{release.name}} </b>
+          <mat-icon *ngIf="i==0">fiber_new</mat-icon>
           <a href="{{release.url}}" target="_blank" matTooltip="Voir depuis Github">
             <mat-icon>link</mat-icon> 
           </a>
@@ -36,7 +36,8 @@
   </mat-accordion>
   <br> <br>
   <span class="custom-br"></span>
-  <h2> Travaux en cours. </h2> 
+  <h2> Travaux en cours... </h2> 
   <img class="wip" src="assets/wip.gif">
   <br> <br> App by TableauBits <br> <br>
 </div>
+<br>

--- a/src/app/components/home-page/home-page.component.html
+++ b/src/app/components/home-page/home-page.component.html
@@ -2,7 +2,28 @@
 <div class="title">
   <h1> <b> MATBAY </b> </h1>
   <h2> Le site des constitutions </h2>
+  <span class="custom-br"></span>
   <h3> Travaux en cours. </h3> 
   <img class="wip" src="assets/wip.gif">
+  <br> <br>
+  <span class="custom-br"></span>
+  <h3> Releases : </h3>
+  <mat-accordion multi class="panel">
+    <mat-expansion-panel *ngFor="let release of releases">
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          {{release.tag_name}}
+        </mat-panel-title>
+        <mat-panel-description>
+          <b> {{release.name}} </b>
+          <a href="{{release.html_url}}" target="_blank" matTooltip="Voir depuis Github">
+            <mat-icon>link</mat-icon> 
+          </a>
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <p>Publié le : {{release.published_at}}</p> <br>
+      <p>{{release.body}}</p>
+    </mat-expansion-panel>
+  </mat-accordion>
   <br> <br> App by TableauBits
 </div>

--- a/src/app/components/home-page/home-page.component.scss
+++ b/src/app/components/home-page/home-page.component.scss
@@ -26,3 +26,7 @@ mat-panel-description {
   justify-content: space-between;
   align-items: center;
 }
+
+.text {
+  text-align: left;
+}

--- a/src/app/components/home-page/home-page.component.scss
+++ b/src/app/components/home-page/home-page.component.scss
@@ -9,3 +9,20 @@ h1 {
   -moz-border-radius: 28px;
   border-radius: 28px;  
 }
+
+mat-expansion-panel {
+  background-color: $mineshaft;
+  color: whitesmoke;
+  width: 50%;
+  margin-left: 25%;
+}
+
+mat-panel-title {
+  color: whitesmoke;
+}
+
+mat-panel-description {
+  color: whitesmoke;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/app/components/home-page/home-page.component.ts
+++ b/src/app/components/home-page/home-page.component.ts
@@ -1,15 +1,32 @@
-import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Component } from '@angular/core';
+
+export interface Release {
+	body: string;
+	html_url: string;
+	name: string;
+	published_at: string;
+	tag_name: string;
+}
 
 @Component({
 	selector: 'app-home-page',
 	templateUrl: './home-page.component.html',
 	styleUrls: ['./home-page.component.scss']
 })
-export class HomePageComponent implements OnInit {
+export class HomePageComponent {
 
-	constructor() { }
+	releases: Release[];
 
-	ngOnInit(): void {
+	constructor(private http: HttpClient) {
+		this.releases = [];
+		this.get() 
 	}
 
+	get(): void {
+		this.http.get('https://api.github.com/repos/TableauBits/Yatga/releases').subscribe((data: any) => {
+			this.releases = data;
+			console.log(this.releases)
+		});
+	}
 }

--- a/src/app/components/home-page/home-page.component.ts
+++ b/src/app/components/home-page/home-page.component.ts
@@ -1,7 +1,28 @@
 import { HttpClient } from '@angular/common/http';
 import { Component } from '@angular/core';
+import { isNil } from 'lodash';
 
-export interface Release {
+interface Changes {
+	author: string;
+	title: string;
+	url: string;
+}
+
+interface BodyRelease {
+	body: string;
+	changes: Changes[];
+	full: string;
+}
+
+interface MatbayRelease {
+	body: BodyRelease;
+	date: string;
+	name: string;
+	url: string;
+	tag: string;
+}
+
+interface GithubRelease {
 	body: string;
 	html_url: string;
 	name: string;
@@ -15,18 +36,49 @@ export interface Release {
 	styleUrls: ['./home-page.component.scss']
 })
 export class HomePageComponent {
-
-	releases: Release[];
+	releases: MatbayRelease[];
 
 	constructor(private http: HttpClient) {
 		this.releases = [];
-		this.get() 
+		this.get();
 	}
 
 	get(): void {
 		this.http.get('https://api.github.com/repos/TableauBits/Yatga/releases').subscribe((data: any) => {
-			this.releases = data;
-			console.log(this.releases)
+			this.releases = (data as GithubRelease[]).map(d => {
+				return {
+					body: this.cleanBody(d.body),
+					date: d.published_at.slice(0, 10),
+					name: d.name,
+					url: d.html_url,
+					tag: d.tag_name,
+				}
+			})
 		});
+	}
+
+	cleanBody(body: string): BodyRelease {
+		let full = "";
+		let changes: Changes[] = []
+		for(let sentence of body.split('\n')) {
+			if (sentence.includes("**Full Changelog**:")) {
+				const index = sentence.indexOf('https://github.com/TableauBits/Yatga');
+				full = sentence.substring(index);
+			} else if (sentence.startsWith("* ")) {
+				const reg = new RegExp(/\* (.*) by @(.*) in (.*)/gm);
+				const result = reg.exec(sentence);
+				if (isNil(result)) continue;
+				changes.push({
+					author: result[2],
+					title: result[1],
+					url: result[3],
+				})
+			}
+		}
+		return {
+			body,
+			changes,
+			full,
+		}
 	}
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -131,6 +131,10 @@ body {
   mat-form-field {
     width: 35%;
   }
+
+  .mat-expansion-panel-header-description, .mat-expansion-indicator::after {
+    color: whitesmoke;
+  }
 }
 
 ::ng-deep {


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Révision de la Home Page et ajout des releases Github sous la forme d'un `mat-accordion`.

### :bug: Bugfix
* Le `.mat-expansion-indicator` devient blanc afin qu'on puisse le voir sur un fond gris.

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie