### PR TITLE
Correction de l'utilisation de l'opérateur OR dans un switch-case

### DIFF
--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -148,7 +148,8 @@ export class ConstitutionComponent implements OnDestroy {
 	private songUpdate(response: CstSongResUpdate) {
 		const songInfo = response.songInfo;
 		switch (response.status) {
-			case "added" || "modified":
+			case "added": 
+			case "modified":
 				this.songs.set(songInfo.id, songInfo);
 				break;
 			case "removed":

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
@@ -61,7 +61,8 @@ export class ManageSongsComponent {
 	private songUpdate(response: CstSongResUpdate) {
 		const songInfo = response.songInfo;
 		switch (response.status) {
-			case "added" || "modified":
+			case "added":
+			case "modified":
 				this.songs.set(songInfo.id, songInfo);
 				break;
 			case "removed":


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :bug: Bugfix
* L'opérateur `||` ne peut pas être utilisé dans un switch-case pour regrouper plusieurs valeurs. Il ne fait que regarder la valeur de gauche.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

* close #84 

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie