### PR TITLE
Refactor des fonctions des Favoris avec la classe YatgaUserFavorites

### DIFF
--- a/src/app/components/constitution-page/constitution.component.html
+++ b/src/app/components/constitution-page/constitution.component.html
@@ -87,10 +87,10 @@
 </nav>
 <div [ngSwitch]="currentSection" class="content">
 	<app-song-list *ngSwitchCase="constitutionSection.SONG_LIST"
-		[songs]="songs" [users]="users" [constitution]="constitution" [favorites]="favorites">
+		[songs]="songs" [users]="users" [constitution]="constitution" [favorites]="getCurrentUserFavs()">
 	</app-song-list>
 	<app-votes *ngSwitchCase="constitutionSection.VOTES"
-		[songs]="songs" [users]="users" [constitution]="constitution" [favorites]="favorites">
+		[songs]="songs" [users]="users" [constitution]="constitution" [favorites]="getCurrentUserFavs()">
 	</app-votes>
 	<app-owner *ngSwitchCase="constitutionSection.OWNER" 
 		[songs]="songs" [users]="users" [constitution]="constitution">

--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -218,4 +218,8 @@ export class ConstitutionComponent implements OnDestroy {
 	updateSongs(): boolean {
 		return canModifySongs(this.constitution);
 	}
+
+	getCurrentUserFavs(): UserFavorites {
+		return this.favorites.get(this.auth.uid) || {uid: "", favs: []};
+	}
 }

--- a/src/app/components/constitution-page/random-song/random-song.component.html
+++ b/src/app/components/constitution-page/random-song/random-song.component.html
@@ -12,8 +12,8 @@
   </iframe>
   <br>
   <button mat-raised-button color="primary" class="margin" matTooltip="Chanson aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
-  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorites() || !canModifyFavorite()">
-    <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
+  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
+    <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>
 </div>
 <button mat-raised-button color="primary" (click)="closeWindow()">

--- a/src/app/components/constitution-page/random-song/random-song.component.html
+++ b/src/app/components/constitution-page/random-song/random-song.component.html
@@ -12,7 +12,7 @@
   </iframe>
   <br>
   <button mat-raised-button color="primary" class="margin" matTooltip="Chanson aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
-  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorties() || !canModifyFavorite()">
+  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorites() || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
   </button>
 </div>

--- a/src/app/components/constitution-page/random-song/random-song.component.html
+++ b/src/app/components/constitution-page/random-song/random-song.component.html
@@ -12,7 +12,7 @@
   </iframe>
   <br>
   <button mat-raised-button color="primary" class="margin" matTooltip="Chanson aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
-  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()" [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
+  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite(currentSong, auth)" [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>
 </div>

--- a/src/app/components/constitution-page/random-song/random-song.component.ts
+++ b/src/app/components/constitution-page/random-song/random-song.component.ts
@@ -1,9 +1,10 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, Message, Song, UserFavorites, canModifyVotes } from 'chelys';
+import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
 import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
+import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { getEmbedURL } from 'src/app/types/url';
 
 interface RandomSongInjectedData {
@@ -17,7 +18,7 @@ interface RandomSongInjectedData {
 	templateUrl: './random-song.component.html',
 	styleUrls: ['./random-song.component.scss']
 })
-export class RandomSongComponent implements OnDestroy {
+export class RandomSongComponent extends YatgaUserFavorites implements OnDestroy  {
 
 	constitution: Constitution;
 	currentSong: Song;
@@ -31,6 +32,7 @@ export class RandomSongComponent implements OnDestroy {
 		private dialogRef: MatDialogRef<RandomSongComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: RandomSongInjectedData
 	) {
+		super();
 		this.constitution = data.constitution;
 		this.songs = data.songs;
 		this.favorites = data.favorites;
@@ -66,11 +68,6 @@ export class RandomSongComponent implements OnDestroy {
 
 	// TODO : DUPLICATION DE CODE
 
-	isAFavorite(): boolean {
-		if (isNil(this.favorites)) return false;
-		return this.favorites.favs.includes(this.currentSong.id);
-	}
-
 	toggleFavorite(): void {
 		if (isNil(this.favorites)) return;
 
@@ -85,15 +82,6 @@ export class RandomSongComponent implements OnDestroy {
 		}
 
 		this.auth.ws.send(message);
-	}
-
-	noMoreFavorties(): boolean {
-		if (isNil(this.favorites)) return false;
-		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(this.currentSong.id);
-	}
-
-	canModifyFavorite(): boolean {
-		return canModifyVotes(this.constitution);
 	}
 
 }

--- a/src/app/components/constitution-page/random-song/random-song.component.ts
+++ b/src/app/components/constitution-page/random-song/random-song.component.ts
@@ -1,8 +1,7 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
-import { isNil } from 'lodash';
+import { Constitution, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { getEmbedURL } from 'src/app/types/url';
@@ -27,7 +26,7 @@ export class RandomSongComponent extends YatgaUserFavorites implements OnDestroy
 	favorites: UserFavorites;
 
 	constructor(
-		private auth: AuthService,
+		public auth: AuthService,
 		private sanitizer: DomSanitizer,
 		private dialogRef: MatDialogRef<RandomSongComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: RandomSongInjectedData
@@ -64,24 +63,6 @@ export class RandomSongComponent extends YatgaUserFavorites implements OnDestroy
 
 	closeWindow(): void {
 		this.dialogRef.close();
-	}
-
-	// TODO : DUPLICATION DE CODE
-
-	toggleFavorite(): void {
-		if (isNil(this.favorites)) return;
-
-		let message: string;
-
-		if (this.favorites.favs.includes(this.currentSong.id)) {
-			// remove the song from favorites
-			message = createMessage<FavReqRemove>(EventType.CST_SONG_FAV_remove, { cstId: this.constitution.id, songId: this.currentSong.id });
-		} else {
-			// add the song to the favorites
-			message = createMessage<FavReqAdd>(EventType.CST_SONG_FAV_add, { cstId: this.constitution.id, songId: this.currentSong.id });
-		}
-
-		this.auth.ws.send(message);
 	}
 
 }

--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -63,7 +63,7 @@
 							<button mat-raised-button color="primary" (click)="onNavigate(song)" matTooltip="Regarder la vidéo sur le site d'origine">
 								<mat-icon>play_circle_outline</mat-icon>
 							</button>
-							<button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorites(song) || !canModifyFavorite()">
+							<button mat-raised-button color="primary" (click)="toggleFavorite(song, auth)" [disabled]="noMoreFavorites(song) || !canModifyFavorite()">
 									<mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
 							</button>
 							<button 
@@ -94,7 +94,7 @@
 		<tr *ngFor="let song of getSongs()">
 			<td> {{ song.id }} </td>
 			<td>
-				<button mat-raised-button color="primary" (click)="toggleFavorite(song)" [disabled]="noMoreFavorites(song) || !canModifyFavorite()">
+				<button mat-raised-button color="primary" (click)="toggleFavorite(song, auth)" [disabled]="noMoreFavorites(song) || !canModifyFavorite()">
 					<mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
 			</button>
 			</td>

--- a/src/app/components/constitution-page/song-list/song-list.component.ts
+++ b/src/app/components/constitution-page/song-list/song-list.component.ts
@@ -3,6 +3,7 @@ import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, EMPTY_CONSTITUTION, EMPTY_USER, EventType, FAVORITES_MAX_LENGTH, Song, SongPlatform, User, UserFavorites, canModifyVotes } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
+import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { CARDS_SORT_KEY, CARDS_VIEW_KEY } from 'src/app/types/local-storage';
 import { compareSongASC, compareSongDSC, compareSongUser } from 'src/app/types/song';
 import { getEmbedURL, getIDFromURL } from 'src/app/types/url';
@@ -14,7 +15,7 @@ import { SongNavigatorComponent } from './song-navigator/song-navigator.componen
 	templateUrl: './song-list.component.html',
 	styleUrls: ['./song-list.component.scss']
 })
-export class SongListComponent {
+export class SongListComponent extends YatgaUserFavorites {
 
 	// Input
 	@Input() constitution: Constitution;
@@ -40,6 +41,7 @@ export class SongListComponent {
 		private auth: AuthService,
 		private dialog: MatDialog
 	) {
+		super();
 		this.constitution = EMPTY_CONSTITUTION;
 		this.currentIframeSongID = -1;
 		this.favorites = {uid: "", favs: []};
@@ -177,10 +179,6 @@ export class SongListComponent {
 		this.setOrderByFavs(false);
 	}
 
-	isAFavorite(song: Song): boolean {
-		return this.favorites.favs.includes(song.id);
-	}
-
 	toggleFavorite(song: Song): void {
 		let message: string;
 
@@ -193,9 +191,5 @@ export class SongListComponent {
 		}
 
 		this.auth.ws.send(message);
-	}
-
-	noMoreFavorites(song: Song): boolean {
-		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(song.id);
 	}
 }

--- a/src/app/components/constitution-page/song-list/song-list.component.ts
+++ b/src/app/components/constitution-page/song-list/song-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, EMPTY_CONSTITUTION, EMPTY_USER, EventType, FAVORITES_MAX_LENGTH, Song, SongPlatform, User, UserFavorites, canModifyVotes } from 'chelys';
+import { canModifySongs, Constitution, EMPTY_CONSTITUTION, EMPTY_USER, Song, SongPlatform, User, UserFavorites, canModifyVotes } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { CARDS_SORT_KEY, CARDS_VIEW_KEY } from 'src/app/types/local-storage';
@@ -38,7 +38,7 @@ export class SongListComponent extends YatgaUserFavorites {
 
 	constructor(
 		private sanitizer: DomSanitizer,
-		private auth: AuthService,
+		public auth: AuthService,
 		private dialog: MatDialog
 	) {
 		super();
@@ -177,19 +177,5 @@ export class SongListComponent extends YatgaUserFavorites {
 	resetOrder() {
 		this.setOrderByUser(false);
 		this.setOrderByFavs(false);
-	}
-
-	toggleFavorite(song: Song): void {
-		let message: string;
-
-		if (this.favorites.favs.includes(song.id)) {
-			// remove the song from favorites
-			message = createMessage<FavReqRemove>(EventType.CST_SONG_FAV_remove, { cstId: this.constitution.id, songId: song.id });
-		} else {
-			// add the song to the favorites
-			message = createMessage<FavReqAdd>(EventType.CST_SONG_FAV_add, { cstId: this.constitution.id, songId: song.id });
-		}
-
-		this.auth.ws.send(message);
 	}
 }

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
@@ -15,7 +15,7 @@
     (click)="changeSong(-1)">
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
-  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()"
+  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite(currentSong, auth)"
     [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
@@ -16,7 +16,7 @@
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()"
-    [disabled]="noMoreFavorties() || !canModifyFavorite()">
+    [disabled]="noMoreFavorites() || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="next-button" [disabled]="!nextSongExist()" (click)="changeSong(1)">

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
@@ -16,8 +16,8 @@
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()"
-    [disabled]="noMoreFavorites() || !canModifyFavorite()">
-    <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
+    [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
+    <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="next-button" [disabled]="!nextSongExist()" (click)="changeSong(1)">
     <mat-icon>keyboard_arrow_right</mat-icon>

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
@@ -1,8 +1,7 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
-import { isNil } from 'lodash';
+import { Constitution, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { getEmbedURL } from 'src/app/types/url';
@@ -28,7 +27,7 @@ export class SongNavigatorComponent extends YatgaUserFavorites implements OnDest
 	favorites: UserFavorites;
 
 	constructor(
-		private auth: AuthService,
+		public auth: AuthService,
 		private sanitizer: DomSanitizer,
 		private dialogRef: MatDialogRef<SongNavigatorComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: SongNavigatorInjectedData,
@@ -78,22 +77,6 @@ export class SongNavigatorComponent extends YatgaUserFavorites implements OnDest
 
 	closeWindow(): void {
 		this.dialogRef.close();
-	}
-
-	toggleFavorite(): void {
-		if (isNil(this.favorites)) return;
-
-		let message: string;
-
-		if (this.favorites.favs.includes(this.currentSong.id)) {
-			// remove the song from favorites
-			message = createMessage<FavReqRemove>(EventType.CST_SONG_FAV_remove, { cstId: this.constitution.id, songId: this.currentSong.id });
-		} else {
-			// add the song to the favorites
-			message = createMessage<FavReqAdd>(EventType.CST_SONG_FAV_add, { cstId: this.constitution.id, songId: this.currentSong.id });
-		}
-
-		this.auth.ws.send(message);
 	}
 
 }

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
@@ -1,9 +1,10 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, Message, Song, UserFavorites, canModifyVotes } from 'chelys';
+import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
 import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
+import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { getEmbedURL } from 'src/app/types/url';
 
 interface SongNavigatorInjectedData {
@@ -18,7 +19,7 @@ interface SongNavigatorInjectedData {
 	templateUrl: './song-navigator.component.html',
 	styleUrls: ['./song-navigator.component.scss']
 })
-export class SongNavigatorComponent implements OnDestroy {
+export class SongNavigatorComponent extends YatgaUserFavorites implements OnDestroy {
 
 	constitution: Constitution;
 	currentSong: Song;
@@ -32,6 +33,8 @@ export class SongNavigatorComponent implements OnDestroy {
 		private dialogRef: MatDialogRef<SongNavigatorComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: SongNavigatorInjectedData,
 	) {
+		super();
+
 		this.constitution = data.constitution;
 		this.currentSong = data.currentSong;
 		this.songs = data.songs;
@@ -77,11 +80,6 @@ export class SongNavigatorComponent implements OnDestroy {
 		this.dialogRef.close();
 	}
 
-	isAFavorite(): boolean {
-		if (isNil(this.favorites)) return false;
-		return this.favorites.favs.includes(this.currentSong.id);
-	}
-
 	toggleFavorite(): void {
 		if (isNil(this.favorites)) return;
 
@@ -96,15 +94,6 @@ export class SongNavigatorComponent implements OnDestroy {
 		}
 
 		this.auth.ws.send(message);
-	}
-
-	noMoreFavorties(): boolean {
-		if (isNil(this.favorites)) return false;
-		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(this.currentSong.id);
-	}
-
-	canModifyFavorite(): boolean {
-		return canModifyVotes(this.constitution);
 	}
 
 }

--- a/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
@@ -16,7 +16,7 @@
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()"
-    [disabled]="noMoreFavorties()">
+    [disabled]="noMoreFavorites()">
     <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="next-button" [disabled]="!nextSongExist()" (click)="changeSong(1)">

--- a/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
@@ -16,8 +16,8 @@
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()"
-    [disabled]="noMoreFavorites()">
-    <mat-icon *ngIf="isAFavorite(); else normalSong" class="favorite">favorite</mat-icon>
+    [disabled]="noMoreFavorites(currentSong)">
+    <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="next-button" [disabled]="!nextSongExist()" (click)="changeSong(1)">
     <mat-icon>keyboard_arrow_right</mat-icon>

--- a/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
@@ -15,7 +15,7 @@
     (click)="changeSong(-1)">
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
-  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite()"
+  <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite(currentSong, auth)"
     [disabled]="noMoreFavorites(currentSong)">
     <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>

--- a/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.ts
@@ -1,15 +1,14 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, GradeReqEdit, GradeResUserDataUpdate, GradeUserData, Message, Song, UserFavorites } from 'chelys';
-import { isNil } from 'lodash';
+import { createMessage, FavResUpdate, EventType, extractMessageData, GradeReqEdit, GradeResUserDataUpdate, GradeUserData, Message, Song, UserFavorites, Constitution } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { getEmbedURL } from 'src/app/types/url';
 import { toMapNumber } from 'src/app/types/utils';
 
 interface VoteNavigatorInjectedData {
-	cstId: string,
+	constitution: Constitution,
 	currentSong: Song,
 	songs: Song[],
 	currentVote: number,
@@ -24,7 +23,7 @@ interface VoteNavigatorInjectedData {
 })
 export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDestroy {
 
-	cstId: string;
+	constitution: Constitution;
 
 	currentSong: Song;
 	currentSongSafeURL: SafeResourceUrl;
@@ -35,14 +34,14 @@ export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDest
 	favorites: UserFavorites;
 
 	constructor(
-		private auth: AuthService,
+		public auth: AuthService,
 		private sanitizer: DomSanitizer,
 		private dialogRef: MatDialogRef<VoteNavigatorComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: VoteNavigatorInjectedData
 	) {
 		super();
 
-		this.cstId = data.cstId;
+		this.constitution = data.constitution;
 		this.currentSong = data.currentSong;
 		this.currentVote = data.currentVote;
 		this.songs = data.songs;
@@ -73,7 +72,7 @@ export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDest
 	}
 
 	vote(grade: number) {
-		const message = createMessage<GradeReqEdit>(EventType.CST_SONG_GRADE_edit, { cstId: this.cstId, voteData: { grade: grade, songId: this.currentSong.id } });
+		const message = createMessage<GradeReqEdit>(EventType.CST_SONG_GRADE_edit, { cstId: this.constitution.id, voteData: { grade: grade, songId: this.currentSong.id } });
 		this.auth.ws.send(message);
 		this.currentVote = grade; // TODO : Necessary ?
 	}
@@ -106,22 +105,6 @@ export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDest
 
 	closeWindow(): void {
 		this.dialogRef.close();
-	}
-
-	toggleFavorite(): void {
-		if (isNil(this.favorites)) return;
-
-		let message: string;
-
-		if (this.favorites.favs.includes(this.currentSong.id)) {
-			// remove the song from favorites
-			message = createMessage<FavReqRemove>(EventType.CST_SONG_FAV_remove, { cstId: this.cstId, songId: this.currentSong.id });
-		} else {
-			// add the song to the favorites
-			message = createMessage<FavReqAdd>(EventType.CST_SONG_FAV_add, { cstId: this.cstId, songId: this.currentSong.id });
-		}
-
-		this.auth.ws.send(message);
 	}
 
 }

--- a/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.ts
@@ -1,9 +1,10 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, FAVORITES_MAX_LENGTH, GradeReqEdit, GradeResUserDataUpdate, GradeUserData, Message, Song, UserFavorites } from 'chelys';
+import { createMessage, FavReqAdd, FavReqRemove, FavResUpdate, EventType, extractMessageData, GradeReqEdit, GradeResUserDataUpdate, GradeUserData, Message, Song, UserFavorites } from 'chelys';
 import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
+import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { getEmbedURL } from 'src/app/types/url';
 import { toMapNumber } from 'src/app/types/utils';
 
@@ -21,7 +22,7 @@ interface VoteNavigatorInjectedData {
 	templateUrl: './vote-navigator.component.html',
 	styleUrls: ['./vote-navigator.component.scss']
 })
-export class VoteNavigatorComponent implements OnDestroy {
+export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDestroy {
 
 	cstId: string;
 
@@ -39,6 +40,8 @@ export class VoteNavigatorComponent implements OnDestroy {
 		private dialogRef: MatDialogRef<VoteNavigatorComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: VoteNavigatorInjectedData
 	) {
+		super();
+
 		this.cstId = data.cstId;
 		this.currentSong = data.currentSong;
 		this.currentVote = data.currentVote;
@@ -105,11 +108,6 @@ export class VoteNavigatorComponent implements OnDestroy {
 		this.dialogRef.close();
 	}
 
-	isAFavorite(): boolean {
-		if (isNil(this.favorites)) return false;
-		return this.favorites.favs.includes(this.currentSong.id);
-	}
-
 	toggleFavorite(): void {
 		if (isNil(this.favorites)) return;
 
@@ -124,11 +122,6 @@ export class VoteNavigatorComponent implements OnDestroy {
 		}
 
 		this.auth.ws.send(message);
-	}
-
-	noMoreFavorties(): boolean {
-		if (isNil(this.favorites)) return false;
-		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(this.currentSong.id);
 	}
 
 }

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -106,7 +106,7 @@
                   <mat-icon>how_to_vote</mat-icon>
                 </button>
                 <button mat-raised-button color="primary" (click)="toggleFavorite(song)"
-                  [disabled]="noMoreFavorties(song) || !canVote()">
+                  [disabled]="noMoreFavorites(song) || !canVote()">
                   <mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
                 </button>
                 <button mat-raised-button color="primary" class="vote" [matMenuTriggerFor]="menu"
@@ -148,7 +148,7 @@
         <td> {{ song.id }} </td>
         <td>
           <button mat-raised-button color="primary" (click)="toggleFavorite(song)"
-            [disabled]="noMoreFavorties(song) || !canVote()">
+            [disabled]="noMoreFavorites(song) || !canVote()">
             <mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
           </button>
         </td>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -105,7 +105,7 @@
                 <button mat-raised-button color="primary" (click)="openVoteNavigator(song)" matTooltip="Voter pour cette chanson">
                   <mat-icon>how_to_vote</mat-icon>
                 </button>
-                <button mat-raised-button color="primary" (click)="toggleFavorite(song)"
+                <button mat-raised-button color="primary" (click)="toggleFavorite(song, auth)"
                   [disabled]="noMoreFavorites(song) || !canVote()">
                   <mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
                 </button>
@@ -147,7 +147,7 @@
       <tr *ngFor="let song of getSongsToVote()">
         <td> {{ song.id }} </td>
         <td>
-          <button mat-raised-button color="primary" (click)="toggleFavorite(song)"
+          <button mat-raised-button color="primary" (click)="toggleFavorite(song, auth)"
             [disabled]="noMoreFavorites(song) || !canVote()">
             <mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
           </button>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -10,6 +10,7 @@ import { getEmbedURL, getIDFromURL } from 'src/app/types/url';
 import { VoteNavigatorComponent } from './vote-navigator/vote-navigator.component';
 import { ActivatedRoute } from '@angular/router';
 import { toMap, toMapNumber } from 'src/app/types/utils';
+import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 
 enum GradeOrder {
 	INCREASE,
@@ -22,7 +23,7 @@ enum GradeOrder {
 	templateUrl: './votes-grade.component.html',
 	styleUrls: ['./votes-grade.component.scss']
 })
-export class VotesGradeComponent implements OnDestroy {
+export class VotesGradeComponent extends YatgaUserFavorites implements OnDestroy {
 
 	@Input() constitution: Constitution = EMPTY_CONSTITUTION;
 	@Input() users: Map<string, User> = new Map();
@@ -55,6 +56,8 @@ export class VotesGradeComponent implements OnDestroy {
 		private dialog: MatDialog,
 		private route: ActivatedRoute,
 	) {
+		super();
+
 		this.currentIframeSongID = -1;
 		this.votes = { uid: this.auth.uid, values: new Map() };
 		this.summary = { voteCount: 0, userCount: new Map() };
@@ -284,10 +287,6 @@ export class VotesGradeComponent implements OnDestroy {
 	}
 
 	// TODO : Implement class ?
-	isAFavorite(song: Song): boolean {
-		return this.favorites.favs.includes(song.id);
-	}
-
 	toggleFavorite(song: Song): void {
 		let message: string;
 
@@ -300,10 +299,6 @@ export class VotesGradeComponent implements OnDestroy {
 		}
 
 		this.auth.ws.send(message);
-	}
-
-	noMoreFavorties(song: Song): boolean {
-		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(song.id);
 	}
 
 }

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -10,7 +10,6 @@ import { getEmbedURL, getIDFromURL } from 'src/app/types/url';
 import { VoteNavigatorComponent } from './vote-navigator/vote-navigator.component';
 import { ActivatedRoute } from '@angular/router';
 import { toMap, toMapNumber } from 'src/app/types/utils';
-import { isNil } from 'lodash';
 
 enum GradeOrder {
 	INCREASE,
@@ -28,7 +27,7 @@ export class VotesGradeComponent implements OnDestroy {
 	@Input() constitution: Constitution = EMPTY_CONSTITUTION;
 	@Input() users: Map<string, User> = new Map();
 	@Input() songs: Map<number, Song> = new Map();
-	@Input() favorites: Map<string, UserFavorites> = new Map();
+	@Input() favorites: UserFavorites;
 
 	safeUrls: Map<number, SafeResourceUrl> = new Map();
 	currentIframeSongID: number;
@@ -59,6 +58,7 @@ export class VotesGradeComponent implements OnDestroy {
 		this.currentIframeSongID = -1;
 		this.votes = { uid: this.auth.uid, values: new Map() };
 		this.summary = { voteCount: 0, userCount: new Map() };
+		this.favorites = {uid: "", favs: []};
 		this.histogramGrades = [];
 		this.cardsSortASC = (localStorage.getItem(CARDS_SORT_KEY) ?? true) === "false";
 		this.cardsViewEnabled = (localStorage.getItem(CARDS_VIEW_KEY) ?? true) !== "false"
@@ -182,7 +182,7 @@ export class VotesGradeComponent implements OnDestroy {
 			currentVote: this.getVote(song),
 			songs: this.getSongsToVote(),
 			votes: this.votes,
-			favorites: this.favorites.get(this.auth.uid)
+			favorites: this.favorites
 		}
 
 		this.dialog.open(VoteNavigatorComponent, config);
@@ -285,18 +285,13 @@ export class VotesGradeComponent implements OnDestroy {
 
 	// TODO : Implement class ?
 	isAFavorite(song: Song): boolean {
-		const userFavorites = this.favorites.get(this.auth.uid);
-		if (isNil(userFavorites)) return false;
-		return userFavorites.favs.includes(song.id);
+		return this.favorites.favs.includes(song.id);
 	}
 
 	toggleFavorite(song: Song): void {
-		const userFavorites = this.favorites.get(this.auth.uid);
-		if (isNil(userFavorites)) return;
-
 		let message: string;
 
-		if (userFavorites.favs.includes(song.id)) {
+		if (this.favorites.favs.includes(song.id)) {
 			// remove the song from favorites
 			message = createMessage<FavReqRemove>(EventType.CST_SONG_FAV_remove, { cstId: this.constitution.id, songId: song.id });
 		} else {
@@ -308,9 +303,7 @@ export class VotesGradeComponent implements OnDestroy {
 	}
 
 	noMoreFavorties(song: Song): boolean {
-		const userFavorites = this.favorites.get(this.auth.uid);
-		if (isNil(userFavorites)) return false;
-		return FAVORITES_MAX_LENGTH === userFavorites.favs.length && !userFavorites.favs.includes(song.id);
+		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(song.id);
 	}
 
 }

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy } from '@angular/core';
 import { AuthService } from 'src/app/services/auth.service';
-import { areResultsPublic, canModifySongs, Constitution, createMessage, FavReqAdd, FavReqRemove, CstResUpdate, EMPTY_CONSTITUTION, EMPTY_USER, EventType, extractMessageData, FAVORITES_MAX_LENGTH, GradeReqGetSummary, GradeReqGetUser, GradeResSummaryUpdate, GradeResUserDataUpdate, GradeSummary, GradeUserData, Message, Song, SongPlatform, User, UserFavorites, canModifyVotes } from 'chelys';
+import { canModifySongs, Constitution, createMessage, CstResUpdate, EMPTY_CONSTITUTION, EMPTY_USER, EventType, extractMessageData, GradeReqGetSummary, GradeReqGetUser, GradeResSummaryUpdate, GradeResUserDataUpdate, GradeSummary, GradeUserData, Message, Song, SongPlatform, User, UserFavorites, canModifyVotes } from 'chelys';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { CARDS_SORT_KEY, CARDS_VIEW_KEY, GRADE_SHOW_STATS_KEY, GRADE_ALREADY_VOTES_KEY } from 'src/app/types/local-storage';
@@ -51,7 +51,7 @@ export class VotesGradeComponent extends YatgaUserFavorites implements OnDestroy
 	orderByGrade: GradeOrder;
 
 	constructor(
-		private auth: AuthService,
+		public auth: AuthService,
 		private sanitizer: DomSanitizer,
 		private dialog: MatDialog,
 		private route: ActivatedRoute,
@@ -180,7 +180,7 @@ export class VotesGradeComponent extends YatgaUserFavorites implements OnDestroy
 		const config = new MatDialogConfig();
 
 		config.data = {
-			cstId: this.constitution.id,
+			constitution: this.constitution,
 			currentSong: song,
 			currentVote: this.getVote(song),
 			songs: this.getSongsToVote(),
@@ -284,21 +284,6 @@ export class VotesGradeComponent extends YatgaUserFavorites implements OnDestroy
 		this.setOrderByUser(false);
 		this.setOrderByFavs(false);
 		this.setOrderByGrade(GradeOrder.NONE)
-	}
-
-	// TODO : Implement class ?
-	toggleFavorite(song: Song): void {
-		let message: string;
-
-		if (this.favorites.favs.includes(song.id)) {
-			// remove the song from favorites
-			message = createMessage<FavReqRemove>(EventType.CST_SONG_FAV_remove, { cstId: this.constitution.id, songId: song.id });
-		} else {
-			// add the song to the favorites
-			message = createMessage<FavReqAdd>(EventType.CST_SONG_FAV_add, { cstId: this.constitution.id, songId: song.id });
-		}
-
-		this.auth.ws.send(message);
 	}
 
 }

--- a/src/app/components/constitution-page/votes/votes.component.ts
+++ b/src/app/components/constitution-page/votes/votes.component.ts
@@ -11,7 +11,7 @@ export class VotesComponent {
 	@Input() constitution: Constitution = EMPTY_CONSTITUTION;
 	@Input() users: Map<string, User> = new Map();
 	@Input() songs: Map<number, Song> = new Map();
-	@Input() favorites: Map<string, UserFavorites> = new Map();
+	@Input() favorites: UserFavorites = { uid: "", favs: []};
 
 	// HTML can't access the ConstiutionType enum directly
 	public get constitutionType(): typeof ConstitutionType {
@@ -19,6 +19,4 @@ export class VotesComponent {
 	}
 
 	constructor() { }
-
-
 }

--- a/src/app/types/extends/favorite.ts
+++ b/src/app/types/extends/favorite.ts
@@ -1,4 +1,5 @@
-import { canModifyVotes, Constitution, EMPTY_CONSTITUTION, FAVORITES_MAX_LENGTH, Song, UserFavorites } from "chelys";
+import { canModifyVotes, Constitution, createMessage, EMPTY_CONSTITUTION, EventType, FAVORITES_MAX_LENGTH, FavReqAdd, FavReqRemove, Song, UserFavorites } from "chelys";
+import { AuthService } from "src/app/services/auth.service";
 
 export class YatgaUserFavorites {
   public constitution: Constitution = EMPTY_CONSTITUTION;
@@ -14,5 +15,19 @@ export class YatgaUserFavorites {
 
   noMoreFavorites(song: Song): boolean {
 		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(song.id);
+	}
+
+	toggleFavorite(song: Song, auth: AuthService): void {
+		let message: string;
+
+		if (this.favorites.favs.includes(song.id)) {
+			// remove the song from favorites
+			message = createMessage<FavReqRemove>(EventType.CST_SONG_FAV_remove, { cstId: this.constitution.id, songId: song.id });
+		} else {
+			// add the song to the favorites
+			message = createMessage<FavReqAdd>(EventType.CST_SONG_FAV_add, { cstId: this.constitution.id, songId: song.id });
+		}
+
+		auth.ws.send(message);
 	}
 }

--- a/src/app/types/extends/favorite.ts
+++ b/src/app/types/extends/favorite.ts
@@ -1,0 +1,22 @@
+import { canModifyVotes, Constitution, EMPTY_CONSTITUTION, EMPTY_SONG, FAVORITES_MAX_LENGTH, Song, UserFavorites } from "chelys";
+import { isNil } from "lodash";
+
+export class YatgaUserFavorites {
+  public constitution: Constitution = EMPTY_CONSTITUTION;
+  public currentSong: Song = EMPTY_SONG;
+  public favorites: UserFavorites = { uid: "", favs: [] };
+
+  canModifyFavorite(): boolean {
+		return canModifyVotes(this.constitution);
+	}
+
+  isAFavorite(): boolean {
+		if (isNil(this.favorites)) return false;
+		return this.favorites.favs.includes(this.currentSong.id);
+	}
+
+  noMoreFavorites(): boolean {
+		if (isNil(this.favorites)) return false;
+		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(this.currentSong.id);
+	}
+}

--- a/src/app/types/extends/favorite.ts
+++ b/src/app/types/extends/favorite.ts
@@ -1,22 +1,18 @@
-import { canModifyVotes, Constitution, EMPTY_CONSTITUTION, EMPTY_SONG, FAVORITES_MAX_LENGTH, Song, UserFavorites } from "chelys";
-import { isNil } from "lodash";
+import { canModifyVotes, Constitution, EMPTY_CONSTITUTION, FAVORITES_MAX_LENGTH, Song, UserFavorites } from "chelys";
 
 export class YatgaUserFavorites {
   public constitution: Constitution = EMPTY_CONSTITUTION;
-  public currentSong: Song = EMPTY_SONG;
   public favorites: UserFavorites = { uid: "", favs: [] };
 
   canModifyFavorite(): boolean {
 		return canModifyVotes(this.constitution);
 	}
 
-  isAFavorite(): boolean {
-		if (isNil(this.favorites)) return false;
-		return this.favorites.favs.includes(this.currentSong.id);
+  isAFavorite(song: Song): boolean {
+		return this.favorites.favs.includes(song.id);
 	}
 
-  noMoreFavorites(): boolean {
-		if (isNil(this.favorites)) return false;
-		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(this.currentSong.id);
+  noMoreFavorites(song: Song): boolean {
+		return FAVORITES_MAX_LENGTH === this.favorites.favs.length && !this.favorites.favs.includes(song.id);
 	}
 }


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->
Réduction de la duplication du code autour des favoris avec l'ajout d'une nouvelle classe.

### :hammer_and_wrench: Refactoring
* Création de la class `YatgaUserFavorites` qui permet de regrouper les implémentations des fonctions `canModifyFavorite`, `isAFavorite`, `noMoreFavorites` et `toggleFavorite` en un seul endroit. Pour les utiliser, il suffit d'extend cette classe et d'utiliser les attributs `constitution` et `favorites`.
* Les components `song-list` et `votes` ne reçoivent plus une map contenant tous les favoris mais seulement les favoris du auth user.
* Correction du nom de fonction `noMoreFavorties`.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie