### PR TITLE
Ajout de la valeur "Instrumental" comme langue

### DIFF
--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.html
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.html
@@ -48,7 +48,7 @@
 					<img *ngIf="!isNil('url')" matSuffix class="platform-img" [src]="songPlatformFromIcon()">
 				</mat-form-field>
 				<h3 class="title"> CHAMPS OPTIONNELS </h3>
-				<span class="custom-br"></span>
+				<hr>
 				<br>
 				<mat-form-field appearance="outline" class="releaseYearField">
 					<mat-label> Année de sortie </mat-label>
@@ -92,8 +92,8 @@
 						</mat-option>
 					</mat-autocomplete>
 				</mat-form-field><br>
-				<mat-icon class="icon" matTooltip="Liste des langues chantées dans la chanson. Il est possible d'en avoir plusieurs ou aucune.">help_outline</mat-icon>
-				<mat-form-field appearance="outline">
+				<mat-icon *ngIf="!isInstrumental()" class="icon" matTooltip="Liste des langues chantées dans la chanson. Il est possible d'en avoir plusieurs ou aucune.">help_outline</mat-icon>
+				<mat-form-field appearance="outline" *ngIf="!isInstrumental()">
 					<mat-label>Langues</mat-label>
 					<mat-chip-list #chipListLanguage>
 						<mat-chip *ngFor="let language of languages" (removed)="remove(language, 'languages')">
@@ -111,9 +111,9 @@
 						</mat-option>
 					</mat-autocomplete>
 				</mat-form-field>
+				<mat-checkbox class="pitie" color="primary" formControlName="isInstrumental"> <mat-label> Il s'agit d'une chanson instrumentale </mat-label> </mat-checkbox>
 			</form>
-			<span class="custom-br"></span>
-			<br>
+			<br> <hr> <br>
 			<button mat-raised-button color="primary" class="icon" (click)="addSong()">
 				Ajouter
 			</button>
@@ -146,7 +146,7 @@
 					</td>
 				</tr>
 			</table>
-			<br>
+			<br> <hr> <br>
 			<button mat-raised-button color="warn" (click)="closeWindow()">
 				Annuler
 			</button>

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.scss
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.scss
@@ -45,6 +45,10 @@ mat-form-field {
   .mat-option.mat-selected:not(.mat-option-multiple):not(.mat-option-disabled) {
     background: $sasuke;
   }
+
+  .mat-checkbox-frame {
+    border-color: whitesmoke;
+  }
 }
 
 table {

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.scss
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.scss
@@ -55,21 +55,21 @@ table {
 }
 
 td, th {
-  border: 1px solid #434647;
+  border: 1px solid $sasuke;
   text-align: center;
   padding: 8px;
 }
 
 #t01 th {
-  background-color: #2E2E2E;
+  background-color: $mineshaft;
   color: whitesmoke;
 }
 
 #t01 tr:nth-child(even) {
-background-color: #434647;
+  background-color: $sasuke;
 }
 #t01 tr:nth-child(odd) {
-background-color: #353738;
+  background-color: $cape-cod;
 }
 
 .icon {

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
@@ -44,7 +44,7 @@ export class ManageSongsComponent implements OnDestroy {
 	public filteredLanguages: Observable<string[]>;
 	private allLanguages: string[];
 	public languagesForm: FormControl;
-	@ViewChild('langageInput') langageInput!: ElementRef<HTMLInputElement>;
+	@ViewChild('languageInput') languageInput!: ElementRef<HTMLInputElement>;
 
 	constructor(
 		private auth: AuthService,
@@ -269,7 +269,7 @@ export class ManageSongsComponent implements OnDestroy {
 				break;
 			case "languages":
 				this.languages.push(event.option.viewValue);
-				this.langageInput.nativeElement.value = '';
+				this.languageInput.nativeElement.value = '';
 				this.languagesForm.setValue(null);
 		}
   }

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.ts
@@ -10,8 +10,8 @@ import { MatChipInputEvent } from '@angular/material/chips';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
-import { removeElementFromArray } from 'src/app/types/utils';
-import { ALL_GENRES, ALL_LANGUAGES_FR, LANGUAGES_FR_TO_CODE } from 'src/app/types/song-utils';
+import { keepUniqueValues, removeElementFromArray } from 'src/app/types/utils';
+import { ALL_GENRES, ALL_LANGUAGES_FR, INSTRUMENTAL_CODE, LANGUAGES_FR_TO_CODE } from 'src/app/types/song-utils';
 
 const ICONS_PATH = "assets/icons";
 
@@ -67,6 +67,7 @@ export class ManageSongsComponent implements OnDestroy {
 			url: [, Validators.required],
 			album: [],
 			releaseYear: [],
+			isInstrumental: [false]
 		});
 
 		this.filteredGenres = this.genresForm.valueChanges.pipe(
@@ -133,6 +134,15 @@ export class ManageSongsComponent implements OnDestroy {
 		this.auth.ws.send(removeSongMessage);
 	}
 
+	getLanguages(): string[] | undefined {
+		if (this.isInstrumental()) return [INSTRUMENTAL_CODE];
+		return isEmpty(this.languages) ? undefined : keepUniqueValues(this.languages.map(langage => LANGUAGES_FR_TO_CODE.get(langage) || ""));
+	}
+
+	isInstrumental(): boolean {
+		return this.newSongForm.value["isInstrumental"] === true;
+	}
+
 	addSong(): void {
 		const invalidValues = this.checkFormValidity();
 		if (!isEmpty(invalidValues)) {
@@ -152,8 +162,8 @@ export class ManageSongsComponent implements OnDestroy {
 				altTitles: isEmpty(this.altTitles) ? undefined : this.altTitles,
 				album: isNull(this.newSongForm.value['album']) ? undefined : this.newSongForm.value['album'],
 				releaseYear: isNull(this.newSongForm.value['releaseYear']) ? undefined : this.newSongForm.value['releaseYear'],
-				genres: isEmpty(this.genres) ? undefined : this.genres,
-				languages: isEmpty(this.languages) ? undefined : this.languages.map(langage => LANGUAGES_FR_TO_CODE.get(langage) || ""),
+				genres: isEmpty(this.genres) ? undefined : keepUniqueValues(this.genres),
+				languages: this.getLanguages(),
 			};
 
 			const newSongMessage = createMessage<CstSongReqAdd>(EventType.CST_SONG_add, { cstId: this.cstID, songData: song });

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -49,7 +49,7 @@
 	<div class="container right">
 		<mat-icon *ngIf="!auth.isConnected" class="warning vertical image-de" matTooltip="Vous êtes déconnecté de Kalimba. Essayez de recharger la page. Si le problème persiste, contactez un administrateur.">cloud_off</mat-icon>
 
-		<button mat-button  [disableRipple]="true" [matMenuTriggerFor]="menu">
+		<button mat-button [matMenuTriggerFor]="menu">
 			<img src="{{auth.user.photoURL}}" class="rounded-circle navbar-button" width="50"	height="50">
 		</button>
 	</div>

--- a/src/app/types/song-utils.ts
+++ b/src/app/types/song-utils.ts
@@ -5,11 +5,16 @@ import { capitalizeFirstLetter } from './utils';
 export const ALL_LANGUAGES_FR = getAll639_1().map((code) => capitalizeFirstLetter(getName(code, "fr") as string)).sort();
 export const LANGUAGES_FR_TO_CODE = new Map<string, string>();
 export const LANGUAGES_CODE_TO_FR = new Map<string, string>();
+export const INSTRUMENTAL_CODE = "ins";
 
+// ISO 639_1
 getAll639_1().forEach((code) => {
-  LANGUAGES_FR_TO_CODE.set(capitalizeFirstLetter(getName(code, "fr") as string),code);
+  LANGUAGES_FR_TO_CODE.set(capitalizeFirstLetter(getName(code, "fr") as string), code);
   LANGUAGES_CODE_TO_FR.set(code, capitalizeFirstLetter(getName(code, "fr") as string));
 });
+
+// Special case
+LANGUAGES_CODE_TO_FR.set(INSTRUMENTAL_CODE, "Instrumental");
 
 export const ALL_GENRES = MUSIC_GENRES.sort().filter((elem, index, self)=> {
   return index === self.indexOf(elem);

--- a/src/app/types/utils.ts
+++ b/src/app/types/utils.ts
@@ -44,6 +44,10 @@ export function capitalizeFirstLetter(value: string) {
 	return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+export function keepUniqueValues<T>(array: T[]): T[] {
+	return [...new Set<T>(array)];
+}
+
 /**
  * Creates a function that compares two objects by a given key.
  * @template T The type of the objects to compare.


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout d'une boîte à cocher signalant qu'une chanson est instrumentale et qui remplace alors les langues données.

### :bug: Bugfix
* Une typo dans le nom d'une variable empêchait de pouvoir sélectionner plusieurs langues à la fois.
* Le component manage-songs n'utilisait pas les variables SCSS de couleurs.

### :hammer_and_wrench: Refactoring
* Ajout de la valeur "Instrumental" et de sa clé "ins".

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

* Close #117

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie