### PR TITLE
Ajout de la sous-section "Constitution" dans la page des résultats

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { ManageInvitesComponent } from './components/admin-page/manage-invites/m
 import { ManageRolesComponent } from './components/admin-page/manage-roles/manage-roles.component';
 import { InvitePageComponent } from './components/invite-page/invite-page.component';
 import { OptionnalSongInfosButtonComponent } from './components/constitution-page/optionnal-song-infos-button/optionnal-song-infos-button.component';
+import { ResultsConstitutionComponent } from './components/constitution-page/results/results-constitution/results-constitution.component';
 
 // Charts Component
 import { HistogramComponent } from './components/template/histogram/histogram.component';
@@ -138,6 +139,7 @@ import { AuthService } from './services/auth.service';
 		ManageRolesComponent,
 		InvitePageComponent,
 		OptionnalSongInfosButtonComponent,
+  ResultsConstitutionComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/constitution-page/optionnal-song-infos-button/optionnal-song-infos-button.component.ts
+++ b/src/app/components/constitution-page/optionnal-song-infos-button/optionnal-song-infos-button.component.ts
@@ -4,7 +4,7 @@ import { isArray, isNil } from 'lodash';
 import { LANGUAGES_CODE_TO_FR } from 'src/app/types/song-utils';
 
 type SongKey = keyof Song;
-const OPTIONNAL_FIELDS: SongKey[] = ["album", "altTitles", "genres", "releaseYear", "languages"];
+const OPTIONNAL_FIELDS: SongKey[] = ["album", "genres", "releaseYear", "languages"];
 
 @Component({
   selector: 'app-optionnal-song-infos-button',

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -10,6 +10,14 @@
         <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
       </mat-select>
     </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label> Choisir le regroupement par année </mat-label>
+      <mat-select [(value)]="releaseYearGroupBy" (selectionChange)="newSelection()">
+        <mat-option value="1">1 an</mat-option>
+        <mat-option value="5">5 ans</mat-option>
+        <mat-option value="10">10 ans</mat-option>
+      </mat-select>
+    </mat-form-field>
     <app-histogram [id]="'results-constitution-years-histogram'" [columns]="releaseYearHistogramColumns" [values]="releaseYearHistogramValues"> </app-histogram>
   </mat-expansion-panel>
 </mat-accordion>

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -1,0 +1,15 @@
+<mat-accordion multi class="panel">
+  <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel-header>
+      <mat-panel-title> Répartiton des années de sorties </mat-panel-title>
+    </mat-expansion-panel-header>
+    Résumé de :
+    <mat-form-field appearance="fill">
+      <mat-label> Choisir un utilisateur </mat-label>
+      <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
+        <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <app-histogram [id]="'results-constitution-years-histogram'" [columns]="releaseYearHistogramColumns" [values]="releaseYearHistogramValues"> </app-histogram>
+  </mat-expansion-panel>
+</mat-accordion>

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.scss
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.scss
@@ -1,0 +1,42 @@
+@import "../../../../../styles/variables.scss";
+
+mat-select {
+  color: whitesmoke;
+}
+
+mat-select-value {
+  color: whitesmoke !important;
+}
+
+::ng-deep {
+  .mat-form-field-appearance-outline .mat-form-field-outline {
+    color: whitesmoke;
+  }
+  .mat-form-field.mat-focused .mat-form-field-label {
+    color: whitesmoke !important;
+  }
+
+  .mat-select-value {
+    color: whitesmoke;
+  }
+
+  mat-form-field {
+      .mat-hint, input, ::placeholder, .mat-form-field-label {
+          color: whitesmoke;
+      }
+  }
+
+  .mat-primary .mat-option:hover {
+    background-color: $sasuke;
+  }
+
+  .mat-option.mat-active {
+    color: whitesmoke;
+    background-color: $cape-cod;
+  }
+
+  .mat-select-panel .mat-option.mat-selected:not(.mat-option-multiple) {
+    color: whitesmoke;
+    background-color: $angular-purple;
+  }
+}

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.spec.ts
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResultsConstitutionComponent } from './results-constitution.component';
+
+describe('ResultsConstitutionComponent', () => {
+  let component: ResultsConstitutionComponent;
+  let fixture: ComponentFixture<ResultsConstitutionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ResultsConstitutionComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResultsConstitutionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
@@ -1,0 +1,93 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Constitution, EMPTY_CONSTITUTION, EMPTY_USER, Song, User } from 'chelys';
+import { isEmpty, isNil, max, min, range } from 'lodash';
+
+const CONSTITUTION_USER_ID = "current-constitution";
+const RELEASE_YEAR_GROUP_BY = [1, 5, 10];
+
+@Component({
+  selector: 'app-results-constitution',
+  templateUrl: './results-constitution.component.html',
+  styleUrls: ['./results-constitution.component.scss']
+})
+export class ResultsConstitutionComponent implements OnChanges {
+
+  @Input() users: Map<string, User> = new Map();
+  @Input() constitution: Constitution = EMPTY_CONSTITUTION;
+  @Input() songs: Map<number, Song> = new Map();
+
+  resultsUsers: Map<string, User> = new Map();
+  selectedUser: string;
+
+  releaseYearHistogramValues: number[] = [];
+  releaseYearHistogramColumns: number[] = [];
+  releaseYearGroupBy: number = RELEASE_YEAR_GROUP_BY[2];
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const usersChange = changes["users"].currentValue as Map<string, User>;
+
+    usersChange.forEach((value, key) => {
+      this.resultsUsers.set(key, value);
+    });
+
+    const cstChange = changes["constitution"].currentValue as Constitution;
+    this.resultsUsers.set(CONSTITUTION_USER_ID, {
+      ...EMPTY_USER,
+      uid: CONSTITUTION_USER_ID,
+      displayName: cstChange.name,
+    });
+
+    this.generateHistogramData();
+  }
+
+  constructor() {
+    this.selectedUser = CONSTITUTION_USER_ID;
+  }
+
+  getUserList(): User[] {
+    return Array.from(this.resultsUsers.values());
+  }
+
+  getSelectedUser(): User {
+    return this.resultsUsers.get(this.selectedUser) || EMPTY_USER;
+  }
+
+  newSelection(): void {
+    this.generateHistogramData();
+  }
+
+  yearFilter(song: Song): boolean {
+    // return true if the year isn't unfedined and the song is from the selectedUser
+    if (isNil(song?.releaseYear)) return false;
+    if (this.selectedUser === CONSTITUTION_USER_ID) return true;  // special case for the constitution where we return all the songs
+    else if (this.selectedUser === song.user) return true;
+    return false;
+  }
+
+  toDecade(year: number | undefined) {
+    if (isNil(year)) return;
+    return Math.floor((year) / this.releaseYearGroupBy) * this.releaseYearGroupBy;
+  }
+
+  generateHistogramData(): void {
+    const years = Array.from(this.songs.values())
+      .filter(song => this.yearFilter(song))
+      .map(song => this.toDecade(song.releaseYear)) as number[];
+
+    if (isEmpty(years)) {
+      this.releaseYearHistogramColumns = [];
+      this.releaseYearHistogramValues = [];
+    };
+
+    const minYear = min(years);
+    const maxYear = max(years);
+
+    if (isNil(minYear) || isNil(maxYear)) return;
+
+    this.releaseYearHistogramColumns = range(minYear, maxYear + 1, this.releaseYearGroupBy);
+    this.releaseYearHistogramValues = years;
+  }
+
+
+
+}

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
@@ -3,7 +3,6 @@ import { Constitution, EMPTY_CONSTITUTION, EMPTY_USER, Song, User } from 'chelys
 import { isEmpty, isNil, max, min, range } from 'lodash';
 
 const CONSTITUTION_USER_ID = "current-constitution";
-const RELEASE_YEAR_GROUP_BY = [1, 5, 10];
 
 @Component({
   selector: 'app-results-constitution',
@@ -21,7 +20,7 @@ export class ResultsConstitutionComponent implements OnChanges {
 
   releaseYearHistogramValues: number[] = [];
   releaseYearHistogramColumns: number[] = [];
-  releaseYearGroupBy: number = RELEASE_YEAR_GROUP_BY[2];
+  releaseYearGroupBy: number;
 
   ngOnChanges(changes: SimpleChanges): void {
     const usersChange = changes["users"].currentValue as Map<string, User>;
@@ -42,6 +41,7 @@ export class ResultsConstitutionComponent implements OnChanges {
 
   constructor() {
     this.selectedUser = CONSTITUTION_USER_ID;
+    this.releaseYearGroupBy = 10;
   }
 
   getUserList(): User[] {

--- a/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.html
@@ -41,7 +41,7 @@
     Moyenne : {{selecedUserMean.toFixed(3)}}
     <br>
     Variance : {{selectedUserVar.toFixed(3)}}
-    <app-histogram [id]="'grade-grades-histogram'" [values]="histogramValues"> </app-histogram>
+    <app-histogram [id]="'grade-grades-histogram'" [columns]="GRADE_VALUES" [values]="histogramValues"> </app-histogram>
   </mat-expansion-panel>
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header> 

--- a/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.ts
@@ -5,6 +5,7 @@ import { AuthService } from 'src/app/services/auth.service';
 import { GetUrlService } from 'src/app/services/get-url.service';
 import { mean, variance } from 'src/app/types/math';
 import { SongGrade, UserGradeResults } from 'src/app/types/results';
+import { GRADE_VALUES } from 'src/app/types/song-utils';
 import { compareObjectsFactory } from 'src/app/types/utils';
 
 @Component({
@@ -13,6 +14,7 @@ import { compareObjectsFactory } from 'src/app/types/utils';
   styleUrls: ['./grade-grades.component.scss']
 })
 export class GradeGradesComponent implements OnChanges {
+  readonly GRADE_VALUES = GRADE_VALUES;
 
   @Input() songs: Map<number, Song> = new Map();
   @Input() users: Map<string, User> = new Map();

--- a/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.html
@@ -17,7 +17,7 @@
     <br>
     <br>
     Répartition des notes :
-    <app-histogram [id]="'grade-profile-histogram'" [values]="histogramValues"> </app-histogram>
+    <app-histogram [id]="'grade-profile-histogram'" [columns]="GRADE_VALUES" [values]="histogramValues"> </app-histogram>
   </mat-expansion-panel>
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header> 

--- a/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.ts
@@ -4,6 +4,7 @@ import { isNil } from 'lodash';
 import { AuthService } from 'src/app/services/auth.service';
 import { DownloadService } from 'src/app/services/download.service';
 import { EMPTY_USER_GRADE_RESULTS, SongGrade, SongGradeResult, UserGradeResults } from 'src/app/types/results';
+import { GRADE_VALUES } from 'src/app/types/song-utils';
 
 @Component({
   selector: 'app-grade-profile',
@@ -11,6 +12,7 @@ import { EMPTY_USER_GRADE_RESULTS, SongGrade, SongGradeResult, UserGradeResults 
   styleUrls: ['./grade-profile.component.scss']
 })
 export class GradeProfileComponent implements OnChanges {
+  readonly GRADE_VALUES = GRADE_VALUES;
 
   @Input() result: UserGradeResults = EMPTY_USER_GRADE_RESULTS;
   @Input() users: Map<string, User> = new Map();

--- a/src/app/components/constitution-page/results/results-grade/results-grade.component.html
+++ b/src/app/components/constitution-page/results/results-grade/results-grade.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="constitution.state === 2; then showResults; else hideResults"> </div>
 
 <ng-template #hideResults>
-  La période de résultats n'est pas ouverte.
+	La période de résultats n'est pas ouverte.
 </ng-template>
 
 <ng-template #showResults>
@@ -14,37 +14,41 @@
 					<i class="fas fa-bars"></i>
 				</button>
 				<div class="collapse navbar-collapse" id="navbarNav" mdbCollapse #basicNav="mdbCollapse">
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.RANKING) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.RANKING)">
-					<mat-icon>reorder</mat-icon> Classement
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.CONSTITUTION) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.CONSTITUTION)">
+						<mat-icon>track_changes</mat-icon> Constitution
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.ELECTORAL) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.ELECTORAL)">
-					<mat-icon>important_devices</mat-icon> Soirée Électorale
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.RANKING) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.RANKING)">
+						<mat-icon>reorder</mat-icon> Classement
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.GRADES) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.GRADES)">
-					<mat-icon>poll</mat-icon> Notes
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.ELECTORAL) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.ELECTORAL)">
+						<mat-icon>important_devices</mat-icon> Soirée Électorale
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.AVERAGE) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.AVERAGE)">
-					<mat-icon>poll</mat-icon> Moyennes
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.GRADES) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.GRADES)">
+						<mat-icon>poll</mat-icon> Notes
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.RANKS) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.RANKS)">
-					<mat-icon>poll</mat-icon> Rangs
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.AVERAGE) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.AVERAGE)">
+						<mat-icon>poll</mat-icon> Moyennes
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.RELATIONSHIP) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.RELATIONSHIP)">
-					<mat-icon>share</mat-icon> Relations
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.RANKS) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.RANKS)">
+						<mat-icon>poll</mat-icon> Rangs
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.FAVORITES) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.FAVORITES)">
-					<mat-icon>favorite</mat-icon> Favoris
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.RELATIONSHIP) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.RELATIONSHIP)">
+						<mat-icon>share</mat-icon> Relations
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.PROFIL) ? 'active' : ''" 
-					(click)="setCurrentSection(gradeResultSection.PROFIL)">
-					<mat-icon>account_box</mat-icon> Mon Profil
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.FAVORITES) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.FAVORITES)">
+						<mat-icon>favorite</mat-icon> Favoris
+					</button>
+					<button mat-button [ngClass]="isSectionActive(gradeResultSection.PROFIL) ? 'active' : ''"
+						(click)="setCurrentSection(gradeResultSection.PROFIL)">
+						<mat-icon>account_box</mat-icon> Mon Profil
 					</button>
 				</div>
 			</div>
@@ -52,29 +56,31 @@
 	</div>
 	<br>
 	<div [ngSwitch]="currentSection">
-		<app-grade-ranking *ngSwitchCase="gradeResultSection.RANKING"
-			[users]="users" [songs]="songs" [songResults]="songResults">
+		<app-results-constitution *ngSwitchCase="gradeResultSection.CONSTITUTION" [users]="users" [songs]="songs" [constitution]="constitution">
+		</app-results-constitution>
+		<app-grade-ranking *ngSwitchCase="gradeResultSection.RANKING" [users]="users" [songs]="songs"
+			[songResults]="songResults">
 		</app-grade-ranking>
-		<app-grade-grades *ngSwitchCase="gradeResultSection.GRADES"
-			[users]="users" [songs]="songs" [userResults]="userResults">
+		<app-grade-grades *ngSwitchCase="gradeResultSection.GRADES" [users]="users" [songs]="songs"
+			[userResults]="userResults">
 		</app-grade-grades>
-		<app-grade-average *ngSwitchCase="gradeResultSection.AVERAGE"
-			[users]="users" [userResults]="userResults" [songs]="songs" [numberOfSongsByUser]="constitution.numberOfSongsPerUser">
+		<app-grade-average *ngSwitchCase="gradeResultSection.AVERAGE" [users]="users" [userResults]="userResults"
+			[songs]="songs" [numberOfSongsByUser]="constitution.numberOfSongsPerUser">
 		</app-grade-average>
-		<app-grade-ranks *ngSwitchCase="gradeResultSection.RANKS"
-			[users]="users" [songs]="songs" [songResults]="songResults">
+		<app-grade-ranks *ngSwitchCase="gradeResultSection.RANKS" [users]="users" [songs]="songs"
+			[songResults]="songResults">
 		</app-grade-ranks>
-		<app-results-favorites *ngSwitchCase="gradeResultSection.FAVORITES"
-			[users]="users" [songs]="songs" [favorites]="favorites">
+		<app-results-favorites *ngSwitchCase="gradeResultSection.FAVORITES" [users]="users" [songs]="songs"
+			[favorites]="favorites">
 		</app-results-favorites>
-		<app-grade-profile *ngSwitchCase="gradeResultSection.PROFIL"
-			[users]="users" [songs]="songs" [favorites]="favorites" [result]="getAuthResult()" [songResults]="songResults" [userResults]="userResults" [constitution]="constitution">
+		<app-grade-profile *ngSwitchCase="gradeResultSection.PROFIL" [users]="users" [songs]="songs" [favorites]="favorites"
+			[result]="getAuthResult()" [songResults]="songResults" [userResults]="userResults" [constitution]="constitution">
 		</app-grade-profile>
-		<app-grade-electoral *ngSwitchCase="gradeResultSection.ELECTORAL"
-			[users]="users" [songs]="songs" [favorites]="favorites" [songResults]="songResults" [userResults]="userResults">
-		</app-grade-electoral> 
-		<app-grade-relationship *ngSwitchCase="gradeResultSection.RELATIONSHIP"
-			[users]="users" [songs]="songs" [favorites]="favorites" [songResults]="songResults" [userResults]="userResults">
+		<app-grade-electoral *ngSwitchCase="gradeResultSection.ELECTORAL" [users]="users" [songs]="songs"
+			[favorites]="favorites" [songResults]="songResults" [userResults]="userResults">
+		</app-grade-electoral>
+		<app-grade-relationship *ngSwitchCase="gradeResultSection.RELATIONSHIP" [users]="users" [songs]="songs"
+			[favorites]="favorites" [songResults]="songResults" [userResults]="userResults">
 		</app-grade-relationship>
 	</div>
 </ng-template>

--- a/src/app/components/constitution-page/results/results-grade/results-grade.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/results-grade.component.ts
@@ -13,7 +13,8 @@ enum GradeResultSection {
   FAVORITES,
   PROFIL,
   ELECTORAL,
-  RELATIONSHIP
+  RELATIONSHIP,
+  CONSTITUTION
 }
 
 function compareScore(s1: SongGradeResult, s2: SongGradeResult): number {

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -26,7 +26,7 @@
       <br>
       <br>
       Répartition des notes :
-      <app-histogram [id]="'votes-grade-histogram'" [values]="histogramGrades"> </app-histogram>
+      <app-histogram [id]="'votes-grade-histogram'" [columns]="GRADE_VALUES" [values]="histogramGrades"> </app-histogram>
     </mat-expansion-panel>
   </mat-accordion>
   <br>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -10,6 +10,7 @@ import { VoteNavigatorComponent } from './vote-navigator/vote-navigator.componen
 import { ActivatedRoute } from '@angular/router';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { GetUrlService } from 'src/app/services/get-url.service';
+import { GRADE_VALUES } from 'src/app/types/song-utils';
 
 enum GradeOrder {
 	INCREASE,
@@ -23,6 +24,7 @@ enum GradeOrder {
 	styleUrls: ['./votes-grade.component.scss']
 })
 export class VotesGradeComponent extends YatgaUserFavorites implements OnDestroy {
+	readonly GRADE_VALUES = GRADE_VALUES;
 
 	@Input() constitution: Constitution = EMPTY_CONSTITUTION;
 	@Input() users: Map<string, User> = new Map();

--- a/src/app/components/template/histogram/histogram.component.ts
+++ b/src/app/components/template/histogram/histogram.component.ts
@@ -1,8 +1,6 @@
 import { AfterViewInit, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Charts, EChartsOption } from 'src/app/types/charts';
 
-const GRADE_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]; // TODO : give the values to count with Input
-
 @Component({
   selector: 'app-histogram',
   templateUrl: './histogram.component.html',
@@ -11,6 +9,7 @@ const GRADE_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]; // TODO : give the values 
 export class HistogramComponent extends Charts implements AfterViewInit, OnChanges {
 
   @Input() values: number[] = [];
+  @Input() columns: number[] = [];
   @Input() id: string;
 
   ngAfterViewInit() {
@@ -19,6 +18,7 @@ export class HistogramComponent extends Charts implements AfterViewInit, OnChang
 
   ngOnChanges(changes: SimpleChanges) {
     this.values = changes['values'].currentValue;
+    this.columns = changes['columns'].currentValue;
     this.updateChart();
   }
 
@@ -35,13 +35,13 @@ export class HistogramComponent extends Charts implements AfterViewInit, OnChang
       color: '#673AB7',
       series: [
         {
-          data: GRADE_VALUES.map((grade) => this.count(grade)),
+          data: this.columns.map((column) => this.count(column)),
           type: 'bar'
         }
       ],
       xAxis: {
         type: 'category',
-        data: GRADE_VALUES
+        data: this.columns
       },
       yAxis: {
         type: 'value'

--- a/src/app/components/template/histogram/histogram.component.ts
+++ b/src/app/components/template/histogram/histogram.component.ts
@@ -36,7 +36,8 @@ export class HistogramComponent extends Charts implements AfterViewInit, OnChang
       series: [
         {
           data: this.columns.map((column) => this.count(column)),
-          type: 'bar'
+          type: 'bar',
+          barWidth: '60%',
         }
       ],
       xAxis: {

--- a/src/app/types/song-utils.ts
+++ b/src/app/types/song-utils.ts
@@ -2,6 +2,8 @@ import MUSIC_GENRES from "musicgenres-json/gen/genres.json";
 import { getAll639_1, getName } from 'all-iso-language-codes';
 import { capitalizeFirstLetter } from './utils';
 
+export const GRADE_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
 export const ALL_LANGUAGES_FR = getAll639_1().map((code) => capitalizeFirstLetter(getName(code, "fr") as string)).sort();
 export const LANGUAGES_FR_TO_CODE = new Map<string, string>();
 export const LANGUAGES_CODE_TO_FR = new Map<string, string>();


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout d'une sous-section "Constitution" dans les résultats. Pour le moment contient un graphe sur la répartition de l'année de sortie des chansons.

<img width="1341" alt="Capture d’écran, le 2023-08-12 à 17 10 53" src="https://github.com/TableauBits/Yatga/assets/43498878/b5d537fd-5850-49df-8e6e-588dbb53e6a9">

### :hammer_and_wrench: Refactoring
* Le component `app-histogram` peut maintenant être réutilisé en dehors de la répartition des votes de 1 à 10.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie