### PR TITLE
Refactoring des navigateurs avec la classe `NavigatorSongDisplayComponent`

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,6 +39,7 @@ import { ManageRolesComponent } from './components/admin-page/manage-roles/manag
 import { InvitePageComponent } from './components/invite-page/invite-page.component';
 import { OptionnalSongInfosButtonComponent } from './components/constitution-page/optionnal-song-infos-button/optionnal-song-infos-button.component';
 import { ResultsConstitutionComponent } from './components/constitution-page/results/results-constitution/results-constitution.component';
+import { NavigatorSongDisplayComponent } from './components/constitution-page/navigator-song-display/navigator-song-display.component';
 
 // Charts Component
 import { HistogramComponent } from './components/template/histogram/histogram.component';
@@ -140,6 +141,7 @@ import { AuthService } from './services/auth.service';
 		InvitePageComponent,
 		OptionnalSongInfosButtonComponent,
   ResultsConstitutionComponent,
+  NavigatorSongDisplayComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -180,6 +180,9 @@ export class ConstitutionComponent implements OnDestroy {
 			favorites: this.favorites.get(this.auth.uid),
 		};
 
+		config.width = "780px";
+		config.height = "720px";
+
 		this.dialog.open(RandomSongComponent, config);
 	}
 

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.html
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.html
@@ -1,0 +1,10 @@
+<div class="title">
+  <a href="{{song.url}}" target="_blank">
+    <h1 class="remove-margin"> <b> {{song.title}} </b> </h1>
+    <h2 class="remove-margin"> {{getSubTitle()}} </h2>
+  </a>
+  <hr>
+  <iframe width="720" height="480" frameborder="0" [src]="songSafeURL" class="iframe-display round"
+    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+  </iframe>
+</div>

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.html
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.html
@@ -1,7 +1,7 @@
 <div class="title">
   <a href="{{song.url}}" target="_blank">
-    <h1 class="remove-margin"> <b> {{song.title}} </b> </h1>
-    <h2 class="remove-margin"> {{getSubTitle()}} </h2>
+    <h1 class="remove-margin text-overflowable"> <b> {{song.title}} </b> </h1>
+    <h2 class="remove-margin text-overflowable"> {{getSubTitle()}} </h2>
   </a>
   <hr>
   <iframe width="720" height="480" frameborder="0" [src]="songSafeURL" class="iframe-display round"

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.scss
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.scss
@@ -1,0 +1,8 @@
+.remove-margin {
+  margin: 0 0 0;
+}
+
+.iframe-display {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.spec.ts
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NavigatorSongDisplayComponent } from './navigator-song-display.component';
+
+describe('NavigatorSongDisplayComponent', () => {
+  let component: NavigatorSongDisplayComponent;
+  let fixture: ComponentFixture<NavigatorSongDisplayComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ NavigatorSongDisplayComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NavigatorSongDisplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.ts
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { SafeResourceUrl } from '@angular/platform-browser';
+import { EMPTY_SONG, Song } from 'chelys';
+import { GetUrlService } from 'src/app/services/get-url.service';
+
+@Component({
+  selector: 'app-navigator-song-display',
+  templateUrl: './navigator-song-display.component.html',
+  styleUrls: ['./navigator-song-display.component.scss']
+})
+export class NavigatorSongDisplayComponent implements OnChanges {
+
+  @Input() song: Song = EMPTY_SONG;
+  songSafeURL: SafeResourceUrl = {};
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.songSafeURL = this.urlGetter.getEmbedURL(changes['song'].currentValue);
+  }
+
+  constructor(public urlGetter: GetUrlService) { }
+
+  getSubTitle(): string {
+    return this.song.album ? `${this.song.author} - ${this.song.album}` : this.song.author
+  }
+
+}

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.ts
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.ts
@@ -20,7 +20,7 @@ export class NavigatorSongDisplayComponent implements OnChanges {
   constructor(public urlGetter: GetUrlService) { }
 
   getSubTitle(): string {
-    return this.song.album ? `${this.song.author} - ${this.song.album}` : this.song.author
+    return this.song.album ? `${this.song.author} - ${this.song.album}` : this.song.author;
   }
 
 }

--- a/src/app/components/constitution-page/random-song/random-song.component.html
+++ b/src/app/components/constitution-page/random-song/random-song.component.html
@@ -1,20 +1,10 @@
+<app-navigator-song-display [song]="currentSong"></app-navigator-song-display>
 <div class="title">
-  <a href="{{currentSong.url}}" target="_blank">
-    <h1 class="text-overflowable"> {{currentSong.author}} - {{currentSong.title}} </h1>
-  </a>
-<hr>
-</div>
-<br>
-<div class="title">
-  <iframe width="640" height="360" frameborder="0"
-      [src]="currentSongSafeURL"
-      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-  </iframe>
-  <br>
   <button mat-raised-button color="primary" class="margin" matTooltip="Chanson aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
   <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite(currentSong, auth)" [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>
+  <app-optionnal-song-infos-button class="favorite-button" [song]="currentSong"> </app-optionnal-song-infos-button>
 </div>
 <button mat-raised-button color="primary" (click)="closeWindow()">
   Fermer

--- a/src/app/components/constitution-page/random-song/random-song.component.ts
+++ b/src/app/components/constitution-page/random-song/random-song.component.ts
@@ -1,8 +1,6 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SafeResourceUrl } from '@angular/platform-browser';
 import { AuthService } from 'src/app/services/auth.service';
-import { GetUrlService } from 'src/app/services/get-url.service';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { Constitution, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
 
@@ -21,13 +19,11 @@ export class RandomSongComponent extends YatgaUserFavorites implements OnDestroy
 
 	constitution: Constitution;
 	currentSong: Song;
-	currentSongSafeURL: SafeResourceUrl;
 	songs: Song[];
 	favorites: UserFavorites;
 
 	constructor(
 		public auth: AuthService,
-		public urlGetter: GetUrlService,
 		private dialogRef: MatDialogRef<RandomSongComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: RandomSongInjectedData
 	) {
@@ -36,7 +32,6 @@ export class RandomSongComponent extends YatgaUserFavorites implements OnDestroy
 		this.songs = data.songs;
 		this.favorites = data.favorites;
 		this.currentSong = this.songs[Math.floor(Math.random() * this.songs.length)];
-		this.currentSongSafeURL = this.urlGetter.getEmbedURL(this.currentSong);
 
 		this.auth.pushEventHandler(this.handleEvent, this);
 	}
@@ -58,7 +53,6 @@ export class RandomSongComponent extends YatgaUserFavorites implements OnDestroy
 
 	changeSong(): void {
 		this.currentSong = this.songs[Math.floor(Math.random() * this.songs.length)];
-		this.currentSongSafeURL = this.urlGetter.getEmbedURL(this.currentSong);
 	}
 
 	closeWindow(): void {

--- a/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-profile/grade-profile.component.ts
@@ -25,7 +25,7 @@ export class GradeProfileComponent implements OnChanges {
   histogramValues: number[] = [];
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.histogramValues = Array.from(changes['result'].currentValue.data.values.values());
+    if (changes['result']) this.histogramValues = Array.from(changes['result'].currentValue.data.values.values());
   }
 
   constructor(private auth: AuthService, private dwl: DownloadService) { }

--- a/src/app/components/constitution-page/song-list/song-list.component.ts
+++ b/src/app/components/constitution-page/song-list/song-list.component.ts
@@ -110,6 +110,9 @@ export class SongListComponent extends YatgaUserFavorites {
 			favorites: this.favorites,
 		};
 
+		config.width = "780px";
+		config.height = "760px";
+
 		this.dialog.open(SongNavigatorComponent, config);
 		this.currentIframeSongID = -1;
 	}

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
@@ -1,16 +1,5 @@
-<div class="title">
-  <a href="{{currentSong.url}}" target="_blank">
-    <h1 class="text-overflowable"> {{currentSong.author}} - {{currentSong.title}} </h1>
-  </a>
-  <hr>
-</div>
-<br>
+<app-navigator-song-display [song]="currentSong"></app-navigator-song-display>
 <div class="title" (window:keydown)="keyPressed($event)">
-  <iframe width="720" height="480" frameborder="0" [src]="currentSongSafeURL"
-    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-  </iframe>
-  <br>
-  <br>
   <button mat-raised-button color="primary" class="previous-button" [disabled]="!previousSongExist()"
     (click)="changeSong(-1)">
     <mat-icon>keyboard_arrow_left</mat-icon>

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
@@ -1,9 +1,7 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SafeResourceUrl } from '@angular/platform-browser';
 import { Constitution, FavResUpdate, EventType, extractMessageData, Message, Song, UserFavorites } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
-import { GetUrlService } from 'src/app/services/get-url.service';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 
 const NEXT_SHIFT = 1;
@@ -25,13 +23,11 @@ export class SongNavigatorComponent extends YatgaUserFavorites implements OnDest
 
 	constitution: Constitution;
 	currentSong: Song;
-	currentSongSafeURL: SafeResourceUrl;
 	songs: Song[];
 	favorites: UserFavorites;
 
 	constructor(
 		public auth: AuthService,
-		public urlGetter: GetUrlService,
 		private dialogRef: MatDialogRef<SongNavigatorComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: SongNavigatorInjectedData,
 	) {
@@ -41,7 +37,6 @@ export class SongNavigatorComponent extends YatgaUserFavorites implements OnDest
 		this.currentSong = data.currentSong;
 		this.songs = data.songs;
 		this.favorites = data.favorites;
-		this.currentSongSafeURL = this.urlGetter.getEmbedURL(this.currentSong);
 
 		this.auth.pushEventHandler(this.handleEvent, this);
 	}
@@ -75,7 +70,6 @@ export class SongNavigatorComponent extends YatgaUserFavorites implements OnDest
 		const currentIndex = this.songs.lastIndexOf(this.currentSong);
 
 		this.currentSong = this.songs[currentIndex + shift];
-		this.currentSongSafeURL = this.urlGetter.getEmbedURL(this.currentSong);
 	}
 
 	keyPressed(keyEvent: KeyboardEvent): void {

--- a/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.html
@@ -1,16 +1,5 @@
-<div class="title">
-  <a href="{{currentSong.url}}" target="_blank">
-    <h1 class="text-overflowable"> {{currentSong.author}} - {{currentSong.title}} </h1>
-  </a>
-  <hr>
-</div>
-<br>
+<app-navigator-song-display [song]="currentSong"></app-navigator-song-display>
 <div class="title" (window:keydown)="keyPressed($event)">
-  <iframe width="720" height="480" frameborder="0" [src]="currentSongSafeURL"
-    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-  </iframe>
-  <br>
-  <br>
   <button mat-raised-button color="primary" class="previous-button" [disabled]="!previousSongExist()"
     (click)="changeSong(-1)">
     <mat-icon>keyboard_arrow_left</mat-icon>

--- a/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/vote-navigator/vote-navigator.component.ts
@@ -1,9 +1,7 @@
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SafeResourceUrl } from '@angular/platform-browser';
 import { createMessage, FavResUpdate, EventType, extractMessageData, GradeReqEdit, GradeResUserDataUpdate, GradeUserData, Message, Song, UserFavorites, Constitution } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
-import { GetUrlService } from 'src/app/services/get-url.service';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { toMapNumber } from 'src/app/types/utils';
 
@@ -29,7 +27,6 @@ export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDest
 	constitution: Constitution;
 
 	currentSong: Song;
-	currentSongSafeURL: SafeResourceUrl;
 	currentVote: number | undefined;
 
 	songs: Song[];
@@ -38,7 +35,6 @@ export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDest
 
 	constructor(
 		public auth: AuthService,
-		public urlGetter: GetUrlService,
 		private dialogRef: MatDialogRef<VoteNavigatorComponent>,
 		@Inject(MAT_DIALOG_DATA) public data: VoteNavigatorInjectedData
 	) {
@@ -50,7 +46,6 @@ export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDest
 		this.songs = data.songs;
 		this.votes = data.votes;
 		this.favorites = data.favorites;
-		this.currentSongSafeURL = this.urlGetter.getEmbedURL(this.currentSong);
 
 		this.auth.pushEventHandler(this.handleEvent, this);
 	}
@@ -103,7 +98,6 @@ export class VoteNavigatorComponent extends YatgaUserFavorites implements OnDest
 
 		this.currentSong = this.songs[currentIndex + shift];
 		this.currentVote = this.votes.values.get(this.currentSong.id);
-		this.currentSongSafeURL = this.urlGetter.getEmbedURL(this.currentSong);
 	}
 
 	keyPressed(keyEvent: KeyboardEvent): void {

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -174,6 +174,9 @@ export class VotesGradeComponent extends YatgaUserFavorites implements OnDestroy
 			favorites: this.favorites
 		};
 
+		config.width = "780px";
+		config.height = "830px";
+
 		this.dialog.open(VoteNavigatorComponent, config);
 		this.currentIframeSongID = -1;
 	}

--- a/src/app/components/template/histogram/histogram.component.ts
+++ b/src/app/components/template/histogram/histogram.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { isNil } from 'lodash';
 import { Charts, EChartsOption } from 'src/app/types/charts';
 
 @Component({
@@ -18,7 +19,7 @@ export class HistogramComponent extends Charts implements AfterViewInit, OnChang
 
   ngOnChanges(changes: SimpleChanges) {
     this.values = changes['values'].currentValue;
-    this.columns = changes['columns'].currentValue;
+    if (changes['columns']) this.columns = changes['columns'].currentValue;
     this.updateChart();
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -32,14 +32,6 @@ hr {
   background-color: $mineshaft !important; 
 }
 
-.custom-br {
-  width: 95%;
-  height: 1px;
-  background-color: $sasuke;
-  margin:auto;
-  display:table;
-}
-
 .picture {
   width: 45px;
   height: 45px;


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Affichage de l'album d'une chanson dans les navigateurs si un album est spécifié.
* Ajout des informations optionnels dans l'onglet des chansons aléatoires.

### :bug: Bugfix
* Correction de la mise à jours de certains éléments d'un histogramme.
* Application de la class `text-overflow` sur un titre d'une chanson trop long dans les navigateurs.

### :hammer_and_wrench: Refactoring
* Retrait de la class sass `custom-br` car inutilisé.
* Utilisation de la classe `NavigatorSongDisplayComponent` regroupant l'affichage du titre et d'un iframe d'une chanson.

![Sans titre](https://github.com/TableauBits/Yatga/assets/43498878/e9cb9281-8e53-4da5-a82e-cfbc6d83d342)


## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie