### PR TITLE
Ajout d'un graph pour visualiser l'ajout des chansons d'une constitution dans le temps

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,6 +48,7 @@ import { ScatterComponent } from './components/template/scatter/scatter.componen
 import { PieComponent } from './components/template/pie/pie.component';
 import { HeatmapComponent } from './components/template/heatmap/heatmap.component';
 import { ChordComponent } from './components/template/chord/chord.component';
+import { CalendarComponent } from './components/template/calendar/calendar.component';
 
 // Grade Component
 import { GradeOwnerComponent } from './components/constitution-page/owner/grade-owner/grade-owner.component';
@@ -86,7 +87,6 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatCardModule } from '@angular/material/card';
-
 
 // MDB
 import { MdbDropdownModule } from 'mdb-angular-ui-kit/dropdown';
@@ -144,6 +144,7 @@ import { AuthService } from './services/auth.service';
 		OptionnalSongInfosButtonComponent,
   ResultsConstitutionComponent,
   NavigatorSongDisplayComponent,
+  CalendarComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -1,6 +1,12 @@
 <mat-accordion multi class="panel">
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header>
+      <mat-panel-title> Ajout des chansons dans le temps </mat-panel-title>
+    </mat-expansion-panel-header>
+    <app-calendar [id]="'results-constitution-calendar'" [data]="calendarData"> </app-calendar>
+  </mat-expansion-panel>
+  <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel-header>
       <mat-panel-title> Répartiton des années de sorties </mat-panel-title>
     </mat-expansion-panel-header>
     Résumé de :

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Constitution, EMPTY_CONSTITUTION, EMPTY_USER, Song, User } from 'chelys';
 import { flatten, isEmpty, isNil, max, min, range } from 'lodash';
-import { PieData } from 'src/app/types/charts';
+import { CalendarData, PieData } from 'src/app/types/charts';
 import { LANGUAGES_CODE_TO_FR } from 'src/app/types/song-utils';
 import { keepUniqueValues } from 'src/app/types/utils';
 
@@ -27,6 +27,8 @@ export class ResultsConstitutionComponent implements OnChanges {
 
   languagesPieData: PieData[] = [];
 
+  calendarData: CalendarData[] = [];
+
   ngOnChanges(changes: SimpleChanges): void {
     const cstChange = changes["constitution"].currentValue as Constitution;
     this.resultsUsers.set(CONSTITUTION_USER_ID, {
@@ -42,6 +44,7 @@ export class ResultsConstitutionComponent implements OnChanges {
 
     this.generateHistogramData();
     this.generatePieDate();
+    this.generateCalendarData();
   }
 
   constructor() {
@@ -108,6 +111,17 @@ export class ResultsConstitutionComponent implements OnChanges {
         name: language,
         value: languages.filter(value => value === language).length
       });
+    }
+  }
+
+  generateCalendarData(): void {
+    const dates = Array.from(this.songs.values()).filter(song => song.addedDate).map(song => {
+      const date = new Date(song.addedDate || "");
+      return `${date.getFullYear()}-${date.getMonth()+1}-${date.getDay()}`;
+    });
+
+    for (const date of keepUniqueValues(dates)) {
+      this.calendarData.push([date, dates.filter(v => v === date).length]);
     }
   }
 

--- a/src/app/components/template/calendar/calendar.component.html
+++ b/src/app/components/template/calendar/calendar.component.html
@@ -1,0 +1,1 @@
+<div (window:resize)="onResize()" id="{{id}}" style="width:100%; height:500px;"></div>

--- a/src/app/components/template/calendar/calendar.component.spec.ts
+++ b/src/app/components/template/calendar/calendar.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CalendarComponent } from './calendar.component';
+
+describe('CalendarComponent', () => {
+  let component: CalendarComponent;
+  let fixture: ComponentFixture<CalendarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CalendarComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CalendarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/template/calendar/calendar.component.ts
+++ b/src/app/components/template/calendar/calendar.component.ts
@@ -1,0 +1,58 @@
+import { AfterViewInit, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { EChartsOption } from 'echarts';
+import { max, min } from 'lodash';
+import { CalendarData, Charts } from 'src/app/types/charts';
+
+@Component({
+  selector: 'app-calendar',
+  templateUrl: './calendar.component.html',
+  styleUrls: ['./calendar.component.scss']
+})
+export class CalendarComponent extends Charts implements AfterViewInit, OnChanges {
+
+  @Input() id: string;
+  @Input() data: CalendarData[] = [];
+
+  ngAfterViewInit() {
+    this.updateChart();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['data']) this.data = changes['data'].currentValue;
+    this.ngAfterViewInit();
+  }
+
+  constructor() {
+    super();
+    this.id = "";
+  }
+
+  generateChartOption(): EChartsOption {
+    const sort = this.data.map(d => d[0]).sort();
+    return {
+      tooltip: {
+        formatter: function (p) {
+          return `${(p as any).data[1]} chansons ajoutées le ${(p as any).data[0]}`;
+        },
+      },
+      visualMap: {
+        show: false,
+      },
+      calendar: {
+        range: [sort[0], sort.reverse()[0]],
+        dayLabel: {
+          color: "#f4f4f4"
+        },
+        monthLabel: {
+          color: "#f4f4f4"
+        }
+      },
+      series: {
+        type: 'heatmap',
+        coordinateSystem: 'calendar',
+        data: this.data
+      }
+    };
+  }
+
+}

--- a/src/app/components/template/heatmap/heatmap.component.ts
+++ b/src/app/components/template/heatmap/heatmap.component.ts
@@ -37,8 +37,17 @@ export class HeatmapComponent extends Charts implements AfterViewInit, OnChanges
   }
 
   generateChartOption(): EChartsOption {
+    const xAxis = this.xAxis;
+    const yAxis = this.yAxis;
     return {
-      tooltip: {},
+      tooltip: {
+        formatter: function (p) {
+          const userX = xAxis[(p as any).data[1]];
+          const userY = yAxis[(p as any).data[0]];
+          const value = (p as any).data[2];
+          return `${userX} vers ${userY} : ${value}`;
+        }
+      },
       grid: {
         height: '50%',
         top: '10%'

--- a/src/app/types/charts.ts
+++ b/src/app/types/charts.ts
@@ -37,6 +37,12 @@ export abstract class Charts {
   abstract generateChartOption(): EChartsOption;
 }
 
+// Calendar
+export type CalendarData = [
+  string, // data {yyyy}-{MM}-{dd}
+  number, // value
+]
+
 // Chord
 export type ChordCategory = {
   name: string;

--- a/src/styles/echarts-theme.json
+++ b/src/styles/echarts-theme.json
@@ -332,6 +332,10 @@
                 "color": "#eeeeee",
                 "width": "1"
             }
+        },
+        "backgroundColor": "#111",
+        "textStyle": {
+          "color": "#f4f4f4"
         }
     },
     "timeline": {


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout d'un graph [Calendar](https://echarts.apache.org/examples/en/editor.html?c=calendar-simple) détaillant quand les chansons d'une constitution ont été ajoutés.

### :tada: Quality of life
* Ajout d'un tooltip personnalisé pour la heatmap entre les utilisateurs.

### :bug: Bugfix
* Ajout du support du dark theme pour les tooltips Echarts.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie