### PR TITLE
Ajout d'un service `SongPropertyManagerService`

### DIFF
--- a/src/app/components/admin-page/new-constitution/new-constitution.component.ts
+++ b/src/app/components/admin-page/new-constitution/new-constitution.component.ts
@@ -38,9 +38,9 @@ export class NewConstitutionComponent {
 		this.errorStatus = new Status();
 	}
 
-	private validateEndDate(control: AbstractControl): {[key: string]: any} | null {
+	private validateEndDate(control: AbstractControl): { [key: string]: any } | null {
 		if (isNil(control.value)) return null;
-		if (new Date(control.value) < new Date()) return {"endDateInvalid": true};
+		if (new Date(control.value) < new Date()) return { "endDateInvalid": true };
 		return null;
 	}
 
@@ -77,7 +77,7 @@ export class NewConstitutionComponent {
 
 	public createConstitution(): void {
 		const invalidValues = this.checkFormValidity();
-		
+
 		if (!isEmpty(invalidValues)) {
 			const text = `Certains champs sont invalides : ${invalidValues.join(', ')}`;
 			this.errorStatus.notify(text, true);

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.html
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.html
@@ -1,7 +1,7 @@
 <div class="title">
   <a href="{{song.url}}" target="_blank">
-    <h1 class="remove-margin text-overflowable"> <b> {{song.title}} </b> </h1>
-    <h2 class="remove-margin text-overflowable"> {{getSubTitle()}} </h2>
+    <h1 class="remove-margin text-overflowable"> <b> {{songPropertyManager.getTitle(song)}} </b> </h1>
+    <h2 class="remove-margin text-overflowable"> {{songPropertyManager.getSubTitle(song)}} </h2>
   </a>
   <hr>
   <iframe width="720" height="480" frameborder="0" [src]="songSafeURL" class="iframe-display round"

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.scss
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.scss
@@ -1,5 +1,5 @@
 .remove-margin {
-  margin: 0 0 0;
+  margin: 0 0 0 0;
 }
 
 .iframe-display {

--- a/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.ts
+++ b/src/app/components/constitution-page/navigator-song-display/navigator-song-display.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { SafeResourceUrl } from '@angular/platform-browser';
 import { EMPTY_SONG, Song } from 'chelys';
 import { GetUrlService } from 'src/app/services/get-url.service';
+import { SongPropertyManagerService } from 'src/app/services/song-property-manager.service';
 
 @Component({
   selector: 'app-navigator-song-display',
@@ -17,10 +18,6 @@ export class NavigatorSongDisplayComponent implements OnChanges {
     this.songSafeURL = this.urlGetter.getEmbedURL(changes['song'].currentValue);
   }
 
-  constructor(public urlGetter: GetUrlService) { }
-
-  getSubTitle(): string {
-    return this.song.album ? `${this.song.author} - ${this.song.album}` : this.song.author;
-  }
+  constructor(public urlGetter: GetUrlService, public songPropertyManager: SongPropertyManagerService) { }
 
 }

--- a/src/app/components/constitution-page/parameters/parameters.component.html
+++ b/src/app/components/constitution-page/parameters/parameters.component.html
@@ -16,16 +16,6 @@
     <td> <mat-slide-toggle [checked]="localSettings.cardsSortDSC" (change)="updateCardsSort()"> </mat-slide-toggle>
     </td>
   </tr>
-  <tr>
-    <td> Affichage des titres </td>
-    <td>
-      <mat-select [value]="localSettings.titlePreference">
-        <mat-option *ngFor="let preference of getTitlePreferences() | keyvalue" [value]="preference">
-          {{preference.value}}
-        </mat-option>
-      </mat-select>
-    </td>
-  </tr>
 </table>
 <br>
 <h2 class="title"> GRADE </h2>

--- a/src/app/components/constitution-page/parameters/parameters.component.html
+++ b/src/app/components/constitution-page/parameters/parameters.component.html
@@ -13,7 +13,18 @@
   </tr>
   <tr>
     <td> Montrer les nouvelles chansons d'abord </td>
-    <td> <mat-slide-toggle [checked]="localSettings.cardsSortDSC" (change)="updateCardsSort()"> </mat-slide-toggle> </td>
+    <td> <mat-slide-toggle [checked]="localSettings.cardsSortDSC" (change)="updateCardsSort()"> </mat-slide-toggle>
+    </td>
+  </tr>
+  <tr>
+    <td> Affichage des titres </td>
+    <td>
+      <mat-select [value]="localSettings.titlePreference">
+        <mat-option *ngFor="let preference of getTitlePreferences() | keyvalue" [value]="preference">
+          {{preference.value}}
+        </mat-option>
+      </mat-select>
+    </td>
   </tr>
 </table>
 <br>
@@ -25,10 +36,12 @@
   </tr>
   <tr>
     <td> Cacher les chansons déjà votées </td>
-    <td> <mat-slide-toggle [checked]="localSettings.gradeShowAlreadyVoted" (change)="updateGradeAlreadyVoted()"> </mat-slide-toggle></td>
+    <td> <mat-slide-toggle [checked]="localSettings.gradeShowAlreadyVoted" (change)="updateGradeAlreadyVoted()">
+      </mat-slide-toggle></td>
   </tr>
   <tr>
     <td> Garder l'onglet "Statistiques" ouvert </td>
-    <td> <mat-slide-toggle [checked]="localSettings.gradeShowStats" (change)="updateGradeShowStats()"> </mat-slide-toggle></td>
+    <td> <mat-slide-toggle [checked]="localSettings.gradeShowStats" (change)="updateGradeShowStats()">
+      </mat-slide-toggle></td>
   </tr>
 </table>

--- a/src/app/components/constitution-page/parameters/parameters.component.scss
+++ b/src/app/components/constitution-page/parameters/parameters.component.scss
@@ -5,11 +5,12 @@ table {
 	margin-left: auto;
 	margin-right: auto;
 	overflow-x: auto;
-	font-size:medium;
+	font-size: medium;
 	width: 33%;
 }
 
-td, th {
+td,
+th {
 	border: 1px solid $sasuke;
 	text-align: center;
 	padding: 8px;

--- a/src/app/components/constitution-page/parameters/parameters.component.ts
+++ b/src/app/components/constitution-page/parameters/parameters.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
-import { CARDS_SORT_KEY, CARDS_VIEW_KEY, GRADE_ALREADY_VOTES_KEY, GRADE_SHOW_STATS_KEY } from 'src/app/types/local-storage';
+import { CARDS_SORT_KEY, CARDS_VIEW_KEY, GRADE_ALREADY_VOTES_KEY, GRADE_SHOW_STATS_KEY, TITLE_PREFERENCE_KEY, TitlePreferences } from 'src/app/types/local-storage';
 
 interface LocalSettings {
-	cardsView: boolean;
+  cardsView: boolean;
   cardsSortDSC: boolean;
   gradeShowAlreadyVoted: boolean;
   gradeShowStats: boolean;
+  titlePreference: TitlePreferences;
 }
 
 @Component({
@@ -18,33 +19,42 @@ export class ParametersComponent {
   public localSettings: LocalSettings;
 
   constructor() {
-    this.localSettings = { 
+    this.localSettings = {
       cardsView: (localStorage.getItem(CARDS_VIEW_KEY) ?? true) !== "false",
       cardsSortDSC: (localStorage.getItem(CARDS_SORT_KEY) ?? true) === "true",
       gradeShowAlreadyVoted: (localStorage.getItem(GRADE_ALREADY_VOTES_KEY) ?? true) === "true",
-      gradeShowStats: (localStorage.getItem(GRADE_SHOW_STATS_KEY) ?? true) === "true"
+      gradeShowStats: (localStorage.getItem(GRADE_SHOW_STATS_KEY) ?? true) === "true",
+      titlePreference: localStorage.getItem(TITLE_PREFERENCE_KEY) as TitlePreferences ?? TitlePreferences.ROMAN
     };
+  }
+
+  public getTitlePreferences(): typeof TitlePreferences {
+    return TitlePreferences;
   }
 
   // TODO : Map & Service ?
   updateCardsView(): void {
-		this.localSettings.cardsView = !this.localSettings.cardsView;
-		localStorage.setItem(CARDS_VIEW_KEY, this.localSettings.cardsView.toString());
-	}
+    this.localSettings.cardsView = !this.localSettings.cardsView;
+    localStorage.setItem(CARDS_VIEW_KEY, this.localSettings.cardsView.toString());
+  }
 
   updateCardsSort(): void {
-		this.localSettings.cardsSortDSC = !this.localSettings.cardsSortDSC;
-		localStorage.setItem(CARDS_SORT_KEY, this.localSettings.cardsSortDSC.toString());
-	}
+    this.localSettings.cardsSortDSC = !this.localSettings.cardsSortDSC;
+    localStorage.setItem(CARDS_SORT_KEY, this.localSettings.cardsSortDSC.toString());
+  }
 
   updateGradeAlreadyVoted(): void {
-		this.localSettings.gradeShowAlreadyVoted = !this.localSettings.gradeShowAlreadyVoted;
-		localStorage.setItem(GRADE_ALREADY_VOTES_KEY, this.localSettings.gradeShowAlreadyVoted.toString());
-	}
+    this.localSettings.gradeShowAlreadyVoted = !this.localSettings.gradeShowAlreadyVoted;
+    localStorage.setItem(GRADE_ALREADY_VOTES_KEY, this.localSettings.gradeShowAlreadyVoted.toString());
+  }
 
   updateGradeShowStats(): void {
-		this.localSettings.gradeShowStats = !this.localSettings.gradeShowStats;
-		localStorage.setItem(GRADE_SHOW_STATS_KEY, this.localSettings.gradeShowStats.toString());
-	}
+    this.localSettings.gradeShowStats = !this.localSettings.gradeShowStats;
+    localStorage.setItem(GRADE_SHOW_STATS_KEY, this.localSettings.gradeShowStats.toString());
+  }
+
+  updateTitlePreference(newPreference: TitlePreferences): void {
+    // this.localSettings.titlePreference = 
+  }
 
 }

--- a/src/app/components/constitution-page/parameters/parameters.component.ts
+++ b/src/app/components/constitution-page/parameters/parameters.component.ts
@@ -1,12 +1,11 @@
 import { Component } from '@angular/core';
-import { CARDS_SORT_KEY, CARDS_VIEW_KEY, GRADE_ALREADY_VOTES_KEY, GRADE_SHOW_STATS_KEY, TITLE_PREFERENCE_KEY, TitlePreferences } from 'src/app/types/local-storage';
+import { CARDS_SORT_KEY, CARDS_VIEW_KEY, GRADE_ALREADY_VOTES_KEY, GRADE_SHOW_STATS_KEY } from 'src/app/types/local-storage';
 
 interface LocalSettings {
   cardsView: boolean;
   cardsSortDSC: boolean;
   gradeShowAlreadyVoted: boolean;
   gradeShowStats: boolean;
-  titlePreference: TitlePreferences;
 }
 
 @Component({
@@ -24,12 +23,7 @@ export class ParametersComponent {
       cardsSortDSC: (localStorage.getItem(CARDS_SORT_KEY) ?? true) === "true",
       gradeShowAlreadyVoted: (localStorage.getItem(GRADE_ALREADY_VOTES_KEY) ?? true) === "true",
       gradeShowStats: (localStorage.getItem(GRADE_SHOW_STATS_KEY) ?? true) === "true",
-      titlePreference: localStorage.getItem(TITLE_PREFERENCE_KEY) as TitlePreferences ?? TitlePreferences.ROMAN
     };
-  }
-
-  public getTitlePreferences(): typeof TitlePreferences {
-    return TitlePreferences;
   }
 
   // TODO : Map & Service ?
@@ -51,10 +45,6 @@ export class ParametersComponent {
   updateGradeShowStats(): void {
     this.localSettings.gradeShowStats = !this.localSettings.gradeShowStats;
     localStorage.setItem(GRADE_SHOW_STATS_KEY, this.localSettings.gradeShowStats.toString());
-  }
-
-  updateTitlePreference(newPreference: TitlePreferences): void {
-    // this.localSettings.titlePreference = 
   }
 
 }

--- a/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
@@ -4,7 +4,8 @@
 <div class="page" (window:keydown)="keyPressed($event)">
   <div class="title">
     <a href="{{currentSong.url}}" target="_blank">
-      <h1 class="text-overflowable"> {{currentRank+1}}. {{currentSong.author}} - {{currentSong.title}} </h1>
+      <h1 class="remove-margin text-overflowable"> {{currentRank+1}}. {{songPropertyManager.getTitle(currentSong)}} </h1>
+      <h2 class="remove-margin text-overflowable"> {{songPropertyManager.getSubTitle(currentSong)}} </h2>
     </a>
     <hr>
   </div>

--- a/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.scss
+++ b/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.scss
@@ -127,3 +127,7 @@ td, th {
     background-color: $angular-purple;
   }
 }
+
+.remove-margin {
+  margin: 0 0 0 0;
+}

--- a/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.ts
@@ -8,6 +8,7 @@ import { SongGradeResult, UserGradeResults } from 'src/app/types/results';
 import * as confetti from 'canvas-confetti';
 import { FIREWORK_DEFAULTS, FIREWORK_DURATION } from 'src/app/types/firework';
 import { GetUrlService } from 'src/app/services/get-url.service';
+import { SongPropertyManagerService } from 'src/app/services/song-property-manager.service';
 
 const NEXT_RESULT = -1;
 const PREVIOUS_RESULT = 1;
@@ -66,7 +67,7 @@ export class GradeElectoralComponent implements OnChanges {
     this.generatePieData();
   }
 
-  constructor(public urlGetter: GetUrlService) {
+  constructor(public urlGetter: GetUrlService, public songPropertyManager: SongPropertyManagerService) {
     this.onWindowResize();
   }
 

--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -41,7 +41,7 @@
 					matTooltip="{{getUser(song.user).displayName}}">
 				<mat-card-title class="card-text text-overflowable"> {{songPropertyManager.getTitle(song)}}
 				</mat-card-title>
-				<mat-card-subtitle class="card-text text-overflowable"> <i> {{songPropertyManager.getSubTitle(song)}}
+				<mat-card-subtitle class="card-text text-overflowable"> <i> {{songPropertyManager.getSubTitle(song, false)}}
 					</i> </mat-card-subtitle>
 			</mat-card-header>
 			<hr>

--- a/src/app/components/constitution-page/song-list/song-list.component.scss
+++ b/src/app/components/constitution-page/song-list/song-list.component.scss
@@ -87,7 +87,7 @@ button {
 	height: 19.5rem;
 	color: whitesmoke;
 	background-color: $mineshaft;
-	z-index: 1;
+	z-index: 0;
 	overflow: hidden;
 	.card-text {
 		width: 21rem;
@@ -121,7 +121,7 @@ button {
 	position: absolute;
 	width: 100%;
 	height: 100%;
-	z-index: -1;
+	z-index: -2;
 	overflow: hidden;
 	opacity: 35%;
 	filter: saturate(2);

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
@@ -73,13 +73,13 @@ export class SongNavigatorComponent extends YatgaUserFavorites implements OnDest
 	}
 
 	keyPressed(keyEvent: KeyboardEvent): void {
-    if (keyEvent.key === 'ArrowRight' && this.nextSongExist()) {
-      this.changeSong(NEXT_SHIFT);
-    }
-    else if (keyEvent.key === 'ArrowLeft' && this.previousSongExist()) {
-      this.changeSong(PREVIOUS_SHIFT);
-    }
-  }
+		if (keyEvent.key === 'ArrowRight' && this.nextSongExist()) {
+			this.changeSong(NEXT_SHIFT);
+		}
+		else if (keyEvent.key === 'ArrowLeft' && this.previousSongExist()) {
+			this.changeSong(PREVIOUS_SHIFT);
+		}
+	}
 
 	closeWindow(): void {
 		this.dialogRef.close();

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -79,8 +79,8 @@
       <mat-card *ngFor="let song of getSongsToVote()" class="card-r">
         <mat-card-header>
           <img mat-card-avatar src="{{getUser(song.user).photoURL}}" matTooltip="{{getUser(song.user).displayName}}">
-          <mat-card-title class="card-text text-overflowable"> {{song.title}}</mat-card-title>
-          <mat-card-subtitle class="card-text text-overflowable"> <i> {{song.author}} </i> </mat-card-subtitle>
+          <mat-card-title class="card-text text-overflowable"> {{songPropertyManager.getTitle(song)}} </mat-card-title>
+          <mat-card-subtitle class="card-text text-overflowable"> <i> {{songPropertyManager.getSubTitle(song, false)}} </i> </mat-card-subtitle>
         </mat-card-header>
         <hr>
         <img src="{{urlGetter.getImageURL(song)}}" class="card-background-img" (click)="updateCurrentIframeSong(song)">

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.scss
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.scss
@@ -120,7 +120,7 @@ mat-form-field {
 	height: 19.5rem;
 	color: whitesmoke;
 	background-color: $mineshaft;
-	z-index: 1;
+	z-index: 0;
 	overflow: hidden;
 	.card-text {
 		width: 21rem;
@@ -154,7 +154,7 @@ mat-form-field {
 	position: absolute;
 	width: 100%;
 	height: 100%;
-	z-index: -1;
+	z-index: -2;
 	overflow: hidden;
 	opacity: 35%;
 	filter: saturate(2);

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.ts
@@ -11,6 +11,7 @@ import { ActivatedRoute } from '@angular/router';
 import { YatgaUserFavorites } from 'src/app/types/extends/favorite';
 import { GetUrlService } from 'src/app/services/get-url.service';
 import { GRADE_VALUES } from 'src/app/types/song-utils';
+import { SongPropertyManagerService } from 'src/app/services/song-property-manager.service';
 
 enum GradeOrder {
 	INCREASE,
@@ -55,7 +56,8 @@ export class VotesGradeComponent extends YatgaUserFavorites implements OnDestroy
 		public auth: AuthService,
 		private dialog: MatDialog,
 		private route: ActivatedRoute,
-		public urlGetter: GetUrlService
+		public urlGetter: GetUrlService,
+		public songPropertyManager: SongPropertyManagerService
 	) {
 		super();
 

--- a/src/app/services/song-property-manager.service.ts
+++ b/src/app/services/song-property-manager.service.ts
@@ -15,6 +15,9 @@ export class SongPropertyManagerService {
   }
 
   getSubTitle(song: Song): string {
-    return song.album ? `${song.author} • ${song.album}` : song.author;
+    let subtitle = song.author;
+    if (song.album) subtitle += ` • ${song.album}`;
+    if (song.releaseYear) subtitle += ` (${song.releaseYear})`;
+    return subtitle;
   }
 }

--- a/src/app/services/song-property-manager.service.ts
+++ b/src/app/services/song-property-manager.service.ts
@@ -14,10 +14,10 @@ export class SongPropertyManagerService {
     return title;
   }
 
-  getSubTitle(song: Song): string {
+  getSubTitle(song: Song, showYear: boolean = true): string {
     let subtitle = song.author;
     if (song.album) subtitle += ` • ${song.album}`;
-    if (song.releaseYear) subtitle += ` (${song.releaseYear})`;
+    if (showYear && song.releaseYear) subtitle += ` (${song.releaseYear})`;
     return subtitle;
   }
 }

--- a/src/app/types/local-storage.ts
+++ b/src/app/types/local-storage.ts
@@ -4,19 +4,10 @@ const CARDS_SORT_KEY = "setting.cardsSort";
 const GRADE_ALREADY_VOTES_KEY = "setting.gradeShowAlreadyVode";
 const GRADE_SHOW_STATS_KEY = "setting.gradeShowStats";
 
-const TITLE_PREFERENCE_KEY = "setting.";
-
-enum TitlePreferences {
-    ROMAN = "ROMAN",
-    ALL_TITLES = "ALL_TITLES",
-    NOT_ROMAN = "NON_ROMAN",
-}
 
 export {
     CARDS_VIEW_KEY,
     CARDS_SORT_KEY,
     GRADE_ALREADY_VOTES_KEY,
     GRADE_SHOW_STATS_KEY,
-    TITLE_PREFERENCE_KEY,
-    TitlePreferences
-}
+};

--- a/src/app/types/local-storage.ts
+++ b/src/app/types/local-storage.ts
@@ -1,5 +1,22 @@
-export const CARDS_VIEW_KEY = "setting.cardsView";
-export const CARDS_SORT_KEY = "setting.cardsSort";
+const CARDS_VIEW_KEY = "setting.cardsView";
+const CARDS_SORT_KEY = "setting.cardsSort";
 
-export const GRADE_ALREADY_VOTES_KEY = "setting.gradeShowAlreadyVode";
-export const GRADE_SHOW_STATS_KEY = "setting.gradeShowStats";
+const GRADE_ALREADY_VOTES_KEY = "setting.gradeShowAlreadyVode";
+const GRADE_SHOW_STATS_KEY = "setting.gradeShowStats";
+
+const TITLE_PREFERENCE_KEY = "setting.";
+
+enum TitlePreferences {
+    ROMAN = "ROMAN",
+    ALL_TITLES = "ALL_TITLES",
+    NOT_ROMAN = "NON_ROMAN",
+}
+
+export {
+    CARDS_VIEW_KEY,
+    CARDS_SORT_KEY,
+    GRADE_ALREADY_VOTES_KEY,
+    GRADE_SHOW_STATS_KEY,
+    TITLE_PREFERENCE_KEY,
+    TitlePreferences
+}


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* Affichage des titres alternatifs, année de sortie et de l'album sur les cards et navigateurs.

### :bug: Bugfix
* Correction du z-index des cards qui passaient alors au dessus de la navra.

### :hammer_and_wrench: Refactoring
* Création d'un nouveau service `SongPropertyManagerService`.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

* En lien avec #118 

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie