### PR TITLE
Adaptation de l'affichage des résultats en fonction de la présence ou non de données optionnelles.

### DIFF
--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -9,36 +9,40 @@
     <mat-expansion-panel-header>
       <mat-panel-title> Répartition des années de sorties </mat-panel-title>
     </mat-expansion-panel-header>
-    Résumé de :
-    <mat-form-field appearance="fill">
-      <mat-label> Choisir un utilisateur </mat-label>
-      <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
-        <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field appearance="fill">
-      <mat-label> Choisir le regroupement par année </mat-label>
-      <mat-select [(value)]="releaseYearGroupBy" (selectionChange)="newSelection()">
-        <mat-option value="1">1 an</mat-option>
-        <mat-option value="5">5 ans</mat-option>
-        <mat-option value="10">10 ans</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <app-histogram *ngIf="propertyExists('releaseYear'); else missingData" [id]="'results-constitution-years-histogram'" [columns]="releaseYearHistogramColumns" [values]="releaseYearHistogramValues"> </app-histogram>
+    <div *ngIf="propertyExists('releaseYear'); else missingData">
+      Résumé de :
+      <mat-form-field appearance="fill">
+        <mat-label> Choisir un utilisateur </mat-label>
+        <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
+          <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label> Choisir le regroupement par année </mat-label>
+        <mat-select [(value)]="releaseYearGroupBy" (selectionChange)="newSelection()">
+          <mat-option value="1">1 an</mat-option>
+          <mat-option value="5">5 ans</mat-option>
+          <mat-option value="10">10 ans</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <app-histogram [id]="'results-constitution-years-histogram'" [columns]="releaseYearHistogramColumns" [values]="releaseYearHistogramValues"> </app-histogram>
+    </div>
   </mat-expansion-panel>
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header>
       <mat-panel-title> Répartition des langues </mat-panel-title>
     </mat-expansion-panel-header>
-    Résumé de :
-    <mat-form-field appearance="fill">
-      <mat-label> Choisir un utilisateur </mat-label>
-      <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
-        <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <app-pie *ngIf="propertyExists('languages'); else missingData" [id]="'results-constitution-languages-pie'" [data]="languagesPieData"> </app-pie>
+    <div *ngIf="propertyExists('languages'); else missingData">
+      Résumé de :
+      <mat-form-field appearance="fill">
+        <mat-label> Choisir un utilisateur </mat-label>
+        <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
+          <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <app-pie [id]="'results-constitution-languages-pie'" [data]="languagesPieData"> </app-pie>
+    </div>
   </mat-expansion-panel>
 </mat-accordion>
 
-<ng-template #missingData> <br> Aucune donnée disponible. </ng-template>
+<ng-template #missingData> Aucune donnée disponible. </ng-template>

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -3,11 +3,11 @@
     <mat-expansion-panel-header>
       <mat-panel-title> Ajout des chansons dans le temps </mat-panel-title>
     </mat-expansion-panel-header>
-    <app-calendar [id]="'results-constitution-calendar'" [data]="calendarData"> </app-calendar>
+    <app-calendar *ngIf="propertyExists('addedDate'); else missingData" [id]="'results-constitution-calendar'" [data]="calendarData"> </app-calendar>
   </mat-expansion-panel>
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header>
-      <mat-panel-title> Répartiton des années de sorties </mat-panel-title>
+      <mat-panel-title> Répartition des années de sorties </mat-panel-title>
     </mat-expansion-panel-header>
     Résumé de :
     <mat-form-field appearance="fill">
@@ -24,11 +24,11 @@
         <mat-option value="10">10 ans</mat-option>
       </mat-select>
     </mat-form-field>
-    <app-histogram [id]="'results-constitution-years-histogram'" [columns]="releaseYearHistogramColumns" [values]="releaseYearHistogramValues"> </app-histogram>
+    <app-histogram *ngIf="propertyExists('releaseYear'); else missingData" [id]="'results-constitution-years-histogram'" [columns]="releaseYearHistogramColumns" [values]="releaseYearHistogramValues"> </app-histogram>
   </mat-expansion-panel>
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header>
-      <mat-panel-title> Répartiton des langues </mat-panel-title>
+      <mat-panel-title> Répartition des langues </mat-panel-title>
     </mat-expansion-panel-header>
     Résumé de :
     <mat-form-field appearance="fill">
@@ -37,6 +37,8 @@
         <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
       </mat-select>
     </mat-form-field>
-    <app-pie [id]="'results-constitution-languages-pie'" [data]="languagesPieData"> </app-pie>
+    <app-pie *ngIf="propertyExists('languages'); else missingData" [id]="'results-constitution-languages-pie'" [data]="languagesPieData"> </app-pie>
   </mat-expansion-panel>
 </mat-accordion>
+
+<ng-template #missingData> <br> Aucune donnée disponible. </ng-template>

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
@@ -125,4 +125,8 @@ export class ResultsConstitutionComponent implements OnChanges {
     }
   }
 
+  propertyExists(property: keyof Song): boolean {
+    return Array.from(this.songs.values()).findIndex((s) => { return !isNil(s[property]); }) !== -1;
+  }
+
 }


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* Ajout de la fonction `propertyExists` qui renvoie le message "Aucune donnée disponible" pour les constitutions n'ayant pas de données optionnelles.

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie