### PR TITLE
Répartition des genres des chansons d'une constitution

### DIFF
--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -32,6 +32,37 @@
   </mat-expansion-panel>
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header>
+      <mat-panel-title> Répartition des genres </mat-panel-title>
+    </mat-expansion-panel-header>
+    <div *ngIf="propertyExists('genres'); else missingData">
+      <mat-form-field appearance="fill">
+        <mat-label> Choisir un utilisateur </mat-label>
+        <mat-select [(value)]="selectedUser" (selectionChange)="newSelection()">
+          <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <table id="t01">
+        <tr>
+          <th> Position </th>
+          <th> Genre </th>
+          <th> Occurence </th>
+          <th> Ajouté par </th>
+        </tr>
+        <tr *ngFor="let genreData of genreTabeData;let indexOfelement=index;">
+          <td> {{ indexOfelement + 1 }} </td>
+          <td> {{ genreData.genre }}</td>
+          <td> {{ genreData.count }}</td>
+          <td> 
+            <div class="same-line" *ngFor="let user of genreData.users">
+              <img class="picture" matTooltip="{{getUser(user).displayName}}" [src]="getUser(user).photoURL">
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </mat-expansion-panel>
+  <mat-expansion-panel [expanded]="false">
+    <mat-expansion-panel-header>
       <mat-panel-title> Répartition des langues </mat-panel-title>
     </mat-expansion-panel-header>
     <div *ngIf="propertyExists('languages'); else missingData">

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.scss
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.scss
@@ -40,3 +40,29 @@ mat-select-value {
     background-color: $angular-purple;
   }
 }
+
+table {
+	margin-left: auto;
+	margin-right: auto;
+	width: 95%;
+	overflow-x: auto;
+	font-size:medium;
+}
+
+td, th {
+	border: 1px solid $sasuke;
+	text-align: center;
+	padding: 8px;
+}
+
+#t01 th {
+	background-color: $mineshaft;
+	color: whitesmoke;
+}
+
+#t01 tr:nth-child(even) {
+	background-color: $sasuke;
+}
+#t01 tr:nth-child(odd) {
+	background-color: $cape-cod;
+}


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Ajout d'une table avec la répartition des genres des chansons d'une constitution dans la zone des résultats.
<img width="1460" alt="Capture d’écran, le 2023-10-03 à 20 50 36" src="https://github.com/TableauBits/Yatga/assets/43498878/7d5b63eb-8a7b-4750-9be8-b99f1975cc91">

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie