### PR TITLE
Changement des mentions de "chanson" en "musique"

### DIFF
--- a/src/app/components/admin-page/new-constitution/new-constitution.component.html
+++ b/src/app/components/admin-page/new-constitution/new-constitution.component.html
@@ -37,10 +37,10 @@
 		<br>
 		<mat-label> Nombre de participants : </mat-label>
 		<mat-slider thumbLabel min="4" max="10" step="1" formControlName="maxUserCount" required></mat-slider>
-		<mat-label> Nombre de chansons par participants : </mat-label>
+		<mat-label> Nombre de musiques par participants : </mat-label>
 		<mat-slider thumbLabel min="1" max="25" step="1" formControlName="numberOfSongsPerUser" required></mat-slider>
 		<br>
-		<span class="warning"> Le nombre total de chanson ne peut dépasser 100 chansons. </span>
+		<span class="warning"> Le nombre total de musique ne peut dépasser 100 musiques. </span>
 		<br>
 		<br>
 		<hr>

--- a/src/app/components/constitution-page/constitution.component.html
+++ b/src/app/components/constitution-page/constitution.component.html
@@ -12,7 +12,7 @@
 			<td> {{songs.size}} / {{constitution.numberOfSongsPerUser * constitution.maxUserCount}} </td>
 		</tr>
 		<tr>
-			<td> Mes chansons </td>
+			<td> Mes musiques </td>
 			<td> {{numberOfSongsOfCurrentUser()}} / {{constitution.numberOfSongsPerUser}} </td>
 		</tr>
 		<tr>
@@ -23,7 +23,7 @@
 	<span class="remaining-time-text"> {{getRemainingTimeMsg()}} </span>
 	<hr>
 	<button mat-raised-button color="primary" [disabled]="!updateSongs()" (click)="openDialogManageSongs()">
-		<mat-icon>apps</mat-icon> Gérer mes chansons
+		<mat-icon>apps</mat-icon> Gérer mes musiques
 	</button>
 	<button mat-raised-button color="primary" (click)="openDialogRandomSong()">
 		<mat-icon>shuffle</mat-icon> Sélection aléatoire
@@ -54,7 +54,7 @@
 		<div class="collapse navbar-collapse" id="navbarNav" mdbCollapse #basicNav="mdbCollapse">
 			<button mat-button [ngClass]="isSectionActive(constitutionSection.SONG_LIST) ? 'active' : ''" 
 							(click)="setCurrentSection(constitutionSection.SONG_LIST)">
-				<mat-icon>queue_music</mat-icon> Liste des Chansons
+				<mat-icon>queue_music</mat-icon> Liste des Musiques
 			</button>
 			<button mat-button [ngClass]="isSectionActive(constitutionSection.VOTES) ? 'active' : ''" 
 							(click)="setCurrentSection(constitutionSection.VOTES)">

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.html
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.html
@@ -1,5 +1,5 @@
 <div class="content" mat-dialog-content>
-	<h1 class="title"> GÉRER MES CHANSONS </h1>
+	<h1 class="title"> GÉRER MES MUSIQUES </h1>
 	<hr>
 	<br>
 	<mat-tab-group mat-align-tabs="center" backgroundColor="primary">
@@ -9,7 +9,7 @@
 				Ajouter
 			</ng-template>
 			<br>
-			<h2 class="title"> AJOUTER UNE CHANSON </h2>
+			<h2 class="title"> AJOUTER UNE MUSIQUE </h2>
 			<hr>
 			<form [formGroup]="newSongForm">
 				<br>
@@ -138,7 +138,7 @@
 				Retirer
 			</ng-template>
 			<br>
-			<h2 class="title"> RETIRER UNE CHANSON </h2>
+			<h2 class="title"> RETIRER UNE MUSIQUE </h2>
 			<hr>
 			<br>
 			<table id="t01">

--- a/src/app/components/constitution-page/manage-songs/manage-songs.component.html
+++ b/src/app/components/constitution-page/manage-songs/manage-songs.component.html
@@ -66,7 +66,7 @@
 					<mat-hint align="end">{{input_album.value.length}}/100</mat-hint>
 				</mat-form-field> <br>
 				<mat-icon class="icon"
-					matTooltip="Autres titres possibles de la chanson. Il peut s'agir de traductions.">help_outline</mat-icon>
+					matTooltip="Autres titres possibles de la musique. Il peut s'agir de traductions.">help_outline</mat-icon>
 				<mat-form-field appearance="outline">
 					<mat-label>Titres alternatifs</mat-label>
 					<mat-chip-list #chipListTitles>
@@ -81,7 +81,7 @@
 					</mat-chip-list>
 				</mat-form-field><br>
 				<mat-icon class="icon"
-					matTooltip="Liste des genres de la chanson. Il est possible d'en avoir plusieurs.">help_outline</mat-icon>
+					matTooltip="Liste des genres de la musique. Il est possible d'en avoir plusieurs.">help_outline</mat-icon>
 				<mat-form-field appearance="outline">
 					<mat-label>Genres</mat-label>
 					<mat-chip-list #chipListGenre>
@@ -101,7 +101,7 @@
 					</mat-autocomplete>
 				</mat-form-field><br>
 				<mat-icon *ngIf="!isInstrumental()" class="icon"
-					matTooltip="Liste des langues chantées dans la chanson. Il est possible d'en avoir plusieurs ou aucune. Sélectionner 'Autre' si aucune langue ne correspond.">help_outline</mat-icon>
+					matTooltip="Liste des langues chantées dans la musique. Il est possible d'en avoir plusieurs ou aucune. Sélectionner 'Autre' si aucune langue ne correspond.">help_outline</mat-icon>
 				<mat-form-field appearance="outline" *ngIf="!isInstrumental()">
 					<mat-label>Langues</mat-label>
 					<mat-chip-list #chipListLanguage>
@@ -121,7 +121,7 @@
 					</mat-autocomplete>
 				</mat-form-field>
 				<mat-checkbox class="pitie" color="primary" formControlName="isInstrumental"> <mat-label> Il s'agit d'une
-						chanson instrumentale </mat-label> </mat-checkbox>
+						musique instrumentale </mat-label> </mat-checkbox>
 			</form>
 			<br>
 			<hr> <br>

--- a/src/app/components/constitution-page/owner/grade-owner/grade-owner.component.ts
+++ b/src/app/components/constitution-page/owner/grade-owner/grade-owner.component.ts
@@ -12,7 +12,7 @@ enum GradeState {
 }
 
 const STATES: Map<GradeState, string> = new Map([
-	[GradeState.SONGS, "Période d'ajout et modification de chansons"],
+	[GradeState.SONGS, "Période d'ajout et modification de musiques"],
 	[GradeState.VOTES, "Période de votes"],
 	[GradeState.RESULTS, "Période de résultats"],
 	[GradeState.NO_STATE, "ERROR"]

--- a/src/app/components/constitution-page/owner/owner.component.html
+++ b/src/app/components/constitution-page/owner/owner.component.html
@@ -13,7 +13,7 @@
       Nombre de participants : {{users.size}}/{{constitution.maxUserCount}}
       <mat-progress-bar mode="determinate" value="{{usersProgressBarValue()}}"></mat-progress-bar>
       <br>
-      Nombre de chansons : {{songs.size}}/{{numberOfSongs()}}
+      Nombre de musiques : {{songs.size}}/{{numberOfSongs()}}
       <mat-progress-bar mode="determinate" value="{{songsProgressBarValue()}}"> </mat-progress-bar>
     </mat-expansion-panel>
     <mat-expansion-panel [expanded]="true">

--- a/src/app/components/constitution-page/parameters/parameters.component.html
+++ b/src/app/components/constitution-page/parameters/parameters.component.html
@@ -12,7 +12,7 @@
     <td> <mat-slide-toggle [checked]="localSettings.cardsView" (change)="updateCardsView()"> </mat-slide-toggle></td>
   </tr>
   <tr>
-    <td> Montrer les nouvelles chansons d'abord </td>
+    <td> Montrer les nouvelles musiques d'abord </td>
     <td> <mat-slide-toggle [checked]="localSettings.cardsSortDSC" (change)="updateCardsSort()"> </mat-slide-toggle>
     </td>
   </tr>
@@ -25,7 +25,7 @@
     <th> </th>
   </tr>
   <tr>
-    <td> Cacher les chansons déjà votées </td>
+    <td> Cacher les musiques déjà votées </td>
     <td> <mat-slide-toggle [checked]="localSettings.gradeShowAlreadyVoted" (change)="updateGradeAlreadyVoted()">
       </mat-slide-toggle></td>
   </tr>

--- a/src/app/components/constitution-page/random-song/random-song.component.html
+++ b/src/app/components/constitution-page/random-song/random-song.component.html
@@ -1,6 +1,6 @@
 <app-navigator-song-display [song]="currentSong"></app-navigator-song-display>
 <div class="title">
-  <button mat-raised-button color="primary" class="margin" matTooltip="Chanson aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
+  <button mat-raised-button color="primary" class="margin" matTooltip="Musique aléatoire" (click)="changeSong()"> <mat-icon>shuffle</mat-icon>  </button>
   <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite(currentSong, auth)" [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
     <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -1,7 +1,7 @@
 <mat-accordion multi class="panel">
   <mat-expansion-panel [expanded]="false">
     <mat-expansion-panel-header>
-      <mat-panel-title> Ajout des chansons dans le temps </mat-panel-title>
+      <mat-panel-title> Ajout des musiques dans le temps </mat-panel-title>
     </mat-expansion-panel-header>
     <app-calendar *ngIf="propertyExists('addedDate'); else missingData" [id]="'results-constitution-calendar'" [data]="calendarData"> </app-calendar>
   </mat-expansion-panel>

--- a/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
@@ -82,6 +82,6 @@
   </div>
 </div>
 <br>
-<b> Répartition actuelle des chansons déjà passées des utilisateurs : </b>
+<b> Répartition actuelle des musiques déjà passées des utilisateurs : </b>
 <br>
 <app-pie [id]="'grade-electoral-pie'" [data]="pieData"> </app-pie>

--- a/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-grades/grade-grades.component.html
@@ -3,9 +3,9 @@
     <mat-expansion-panel-header> 
         <mat-panel-title> Notes </mat-panel-title>
     </mat-expansion-panel-header>
-    Chanson sélectionnée :
+    Musique sélectionnée :
     <mat-form-field appearance="fill">
-      <mat-label> Choisir une chanson </mat-label>
+      <mat-label> Choisir une musique </mat-label>
       <mat-select [(value)]="selectedSong">
         <mat-option *ngFor="let song of getSongList()" value="{{song.id}}" class="text-overflowable"> {{song.author}} - {{song.title}} </mat-option>
       </mat-select>

--- a/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-relationship/grade-relationship.component.html
@@ -6,7 +6,7 @@
     <i>
       La ligne note la colonne.
       Plus le chiffre est grand, plus l'utilisateur de la ligne apprécie l'utilisateur de la colonne.
-      Donne un point lorsqu'une chanson est notée au-dessus de sa moyenne ou si elle est un favori.
+      Donne un point lorsqu'une musique est notée au-dessus de sa moyenne ou si elle est un favori.
     </i>
     <app-heatmap [id]="'grade-relationship-heatmap'" [data]="heatmapData" [xAxis]="xAxisNames" [yAxis]="yAxisNames"> </app-heatmap>
   </mat-expansion-panel>

--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -11,7 +11,7 @@
 		<mat-icon>block</mat-icon>
 	</button>
 	<button mat-raised-button color="primary" class="filter-button" [matMenuTriggerFor]="menu"
-		matTooltip="Classer les chansons">
+		matTooltip="Classer les musiques">
 		<mat-icon>filter_list</mat-icon>
 	</button>
 	<mat-menu #menu="matMenu">
@@ -75,7 +75,7 @@
 				<app-optionnal-song-infos-button class="favorite-button" [song]="song" [isButtonRaised]="false">
 				</app-optionnal-song-infos-button>
 				<button *ngIf="isCurrentUserSong(song)" [disabled]="!canDeleteSong()" mat-button color="warn"
-					class="cancel" (click)="openDeleteSongWarning(song)" matTooltip="Retirer la chanson">
+					class="cancel" (click)="openDeleteSongWarning(song)" matTooltip="Retirer la musique">
 					<mat-icon>cancel</mat-icon>
 				</button>
 			</div>
@@ -116,7 +116,7 @@
 				</app-optionnal-song-infos-button> </td>
 			<td>
 				<button *ngIf="isCurrentUserSong(song)" [disabled]="!canDeleteSong()" mat-button color="warn"
-					(click)="openDeleteSongWarning(song)" matTooltip="Retirer la chanson">
+					(click)="openDeleteSongWarning(song)" matTooltip="Retirer la musique">
 					<mat-icon>cancel</mat-icon>
 				</button>
 			</td>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -11,7 +11,7 @@
         <mat-panel-title> Statistiques </mat-panel-title>
       </mat-expansion-panel-header>
       <mat-checkbox color="primary" [checked]="showAlreadyVoted" (change)="updateGradeAlreadyVoted()"> Cacher les
-        chansons déjà votées </mat-checkbox>
+        musiques déjà votées </mat-checkbox>
       <br>
       <br>
       Mes votes : {{this.votes.values.size}} / {{constitution.numberOfSongsPerUser * (constitution.maxUserCount - 1)}}
@@ -44,7 +44,7 @@
       <mat-icon>block</mat-icon>
     </button>
     <button mat-raised-button color="primary" class="filter-button" [matMenuTriggerFor]="menu"
-      matTooltip="Classer les chansons">
+      matTooltip="Classer les musiques">
       <mat-icon>filter_list</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
@@ -144,7 +144,7 @@
       <tr *ngFor="let song of getSongsToVote()">
         <td>
           <button mat-button color="primary" (click)="toggleFavorite(song, auth)"
-            [disabled]="noMoreFavorites(song) || !canVote()" matTooltip="Voter pour cette chanson">
+            [disabled]="noMoreFavorites(song) || !canVote()" matTooltip="Voter pour cette musique">
             <mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
           </button>
         </td>

--- a/src/app/components/template/calendar/calendar.component.ts
+++ b/src/app/components/template/calendar/calendar.component.ts
@@ -32,7 +32,7 @@ export class CalendarComponent extends Charts implements AfterViewInit, OnChange
     return {
       tooltip: {
         formatter: function (p) {
-          return `${(p as any).data[1]} chansons ajoutées le ${(p as any).data[0]}`;
+          return `${(p as any).data[1]} musiques ajoutées le ${(p as any).data[0]}`;
         },
       },
       visualMap: {


### PR DESCRIPTION
## Description
Cette PR essaye de changer toutes les instances de texte "chanson" en "musique". Le premier commit à été fait avec les commandes suivantes (avec quelques changements exclus, notemment dans la liste des genres):
- `find . -type f -not -path "./node_modules/*" -not -path "./.git/*" -not -path "./.angular/*" -print0 | xargs -0 sed -i '' -e 's/chanson/musique/g'`
- `find . -type f -not -path "./node_modules/*" -not -path "./.git/*" -not -path "./.angular/*" -print0 | xargs -0 sed -i '' -e 's/Chanson/Musique/g'`

La plupart des instances ont été identifées, mais il est possible qu'il en manque par cause de fautes d'orthographe ou autres.

## Checklist

- [x] Titre
- [x] Label
- [x] Catégorie