### PR TITLE
Remplacement de certains pie charts par des bar charts

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -49,6 +49,7 @@ import { PieComponent } from './components/template/pie/pie.component';
 import { HeatmapComponent } from './components/template/heatmap/heatmap.component';
 import { ChordComponent } from './components/template/chord/chord.component';
 import { CalendarComponent } from './components/template/calendar/calendar.component';
+import { InvHistogramComponent } from './components/template/inv-histogram/inv-histogram.component';
 
 // Grade Component
 import { GradeOwnerComponent } from './components/constitution-page/owner/grade-owner/grade-owner.component';
@@ -145,6 +146,7 @@ import { AuthService } from './services/auth.service';
   ResultsConstitutionComponent,
   NavigatorSongDisplayComponent,
   CalendarComponent,
+  InvHistogramComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.html
@@ -73,7 +73,7 @@
           <mat-option *ngFor="let user of getUserList()" value="{{user.uid}}"> {{user.displayName}} </mat-option>
         </mat-select>
       </mat-form-field>
-      <app-pie [id]="'results-constitution-languages-pie'" [data]="languagesPieData"> </app-pie>
+      <app-inv-histogram [id]="'results-constitution-languages-histogram'" [data]="languagesInvHistogramData"> </app-inv-histogram>
     </div>
   </mat-expansion-panel>
 </mat-accordion>

--- a/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
+++ b/src/app/components/constitution-page/results/results-constitution/results-constitution.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Constitution, EMPTY_CONSTITUTION, EMPTY_USER, Song, User } from 'chelys';
-import { flatten, isEmpty, isNil, max, min, range } from 'lodash';
-import { CalendarData, PieData } from 'src/app/types/charts';
+import { isEmpty, isNil, max, min, range } from 'lodash';
+import { CalendarData, InvHistogramData } from 'src/app/types/charts';
 import { mean, median } from 'src/app/types/math';
 import { LANGUAGES_CODE_TO_FR } from 'src/app/types/song-utils';
 import { compareObjectsFactory, keepUniqueValues, toDecade } from 'src/app/types/utils';
@@ -37,8 +37,7 @@ export class ResultsConstitutionComponent implements OnChanges {
   selectedUser: string;
 
   releaseYearSection: ReleaseYearSection;
-
-  languagesPieData: PieData[] = [];
+  languagesInvHistogramData: InvHistogramData;
   calendarData: CalendarData[] = [];
   genreTabeData: GenreTableData[] = [];
 
@@ -56,7 +55,7 @@ export class ResultsConstitutionComponent implements OnChanges {
     });
 
     this.generateHistogramData();
-    this.generatePieDate();
+    this.generateLanguageData();
     this.generateCalendarData();
     this.generateGenreTableData();
   }
@@ -69,6 +68,10 @@ export class ResultsConstitutionComponent implements OnChanges {
       groupBy: 10,
       mean: -1,
       median: -1
+    };
+    this.languagesInvHistogramData = {
+      rows: [],
+      values: [],
     };
   }
 
@@ -86,7 +89,7 @@ export class ResultsConstitutionComponent implements OnChanges {
 
   newSelection(): void {
     this.generateHistogramData();
-    this.generatePieDate();
+    this.generateLanguageData();
     this.generateGenreTableData();
   }
 
@@ -121,27 +124,43 @@ export class ResultsConstitutionComponent implements OnChanges {
     this.releaseYearSection.histogramValues = years;
   }
 
-  generatePieDate(): void {
-    this.languagesPieData = [];
-    const languages = flatten<string>(
-      Array.from(this.songs.values())
+  generateLanguageData(): void {
+    const rows: string[] = [];
+    const values: number[] = [];
+
+    const languages = Array.from(this.songs.values())
       .filter(song => this.songFilter(song, "languages"))
       .map(song => song.languages || [])
-      ).map(language => LANGUAGES_CODE_TO_FR.get(language));
+      .map(languages => {
+        return languages.map(language => LANGUAGES_CODE_TO_FR.get(language)).sort().join(", ");
+      })
+      .sort()
+      .reverse();
 
     for (const language of keepUniqueValues(languages)) {
       if (isNil(language)) return;
-      this.languagesPieData.push({
-        name: language,
-        value: languages.filter(value => value === language).length
-      });
+      rows.push(language);
+      values.push(languages.filter(value => value === language).length);
     }
+
+    // get the indexes of values sorted in descending order
+    const sortedIndexes = values.map((_, i) => i).sort((a, b) => values[a] - values[b]);
+
+    this.languagesInvHistogramData = {
+      rows: sortedIndexes.map(i => rows[i]),
+      values: sortedIndexes.map(i => values[i]),
+      visualMap: {
+        min: 0,
+        max: languages.length,
+        text: ["Beaucoup de musiques", "Peu de musiques",]
+      }
+    };
   }
 
   generateCalendarData(): void {
     const dates = Array.from(this.songs.values()).filter(song => song.addedDate).map(song => {
       const date = new Date(song.addedDate || "");
-      return `${date.getFullYear()}-${date.getMonth()+1}-${date.getDay()}`;
+      return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDay()}`;
     });
 
     for (const date of keepUniqueValues(dates)) {

--- a/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
+++ b/src/app/components/constitution-page/results/results-grade/grade-electoral/grade-electoral.component.html
@@ -20,7 +20,7 @@
     <br>
     <div *ngIf="getFavoriteForUser().length === 0" class="no_data"> Pas de favoris </div>
     <div class="same-line" *ngFor="let fav of getFavoriteForUser()">
-      <img class="picture" matTooltip="{{getUser(fav.uid).displayName}}" [src]="getUser(fav.uid).photoURL">
+      <img class="picture3" matTooltip="{{getUser(fav.uid).displayName}}" [src]="getUser(fav.uid).photoURL">
       <mat-icon class="favorite love">favorite</mat-icon>
     </div>
     <br> 
@@ -28,7 +28,7 @@
     <hr>
     <div>
       <br>
-      Ajouté par : <img class="picture" matTooltip="{{getUser(currentSong.user).displayName}}" [src]="getUser(currentSong.user).photoURL">
+      Ajouté par : <img class="picture3" matTooltip="{{getUser(currentSong.user).displayName}}" [src]="getUser(currentSong.user).photoURL">
       <app-optionnal-song-infos-button class="favorite-button" [song]="currentSong" [isButtonRaised]="false"></app-optionnal-song-infos-button>
       <br>
       Score : <b> {{songResults[currentRank].score.toFixed(3)}} </b>
@@ -48,7 +48,7 @@
         <th style="width: 15%;"> Note </th>
       </tr>
       <tr *ngFor="let votingUser of currentVoters">
-        <td style="width: 15%;"> <img class="picture" [src]="votingUser.user.photoURL"> </td>
+        <td style="width: 15%;"> <img class="picture3" [src]="votingUser.user.photoURL"> </td>
         <td style="width: 55%;"> {{ votingUser.user.displayName }} </td>
         <td style="width: 15%;"> {{ votingUser.score.toFixed(3) }}</td>
         <td style="width: 15%;"> {{ votingUser.grade }}</td>
@@ -84,4 +84,4 @@
 <br>
 <b> Répartition actuelle des musiques déjà passées des utilisateurs : </b>
 <br>
-<app-pie [id]="'grade-electoral-pie'" [data]="pieData"> </app-pie>
+<app-inv-histogram [id]="'results-constitution-histogram'" [data]="invHistogramData"> </app-inv-histogram>

--- a/src/app/components/template/inv-histogram/inv-histogram.component.html
+++ b/src/app/components/template/inv-histogram/inv-histogram.component.html
@@ -1,0 +1,1 @@
+<div (window:resize)="onResize()" id="{{id}}" style="width:100%; height:500%;"></div>

--- a/src/app/components/template/inv-histogram/inv-histogram.component.spec.ts
+++ b/src/app/components/template/inv-histogram/inv-histogram.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InvHistogramComponent } from './inv-histogram.component';
+
+describe('InvHistogramComponent', () => {
+  let component: InvHistogramComponent;
+  let fixture: ComponentFixture<InvHistogramComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ InvHistogramComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InvHistogramComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/template/inv-histogram/inv-histogram.component.ts
+++ b/src/app/components/template/inv-histogram/inv-histogram.component.ts
@@ -1,0 +1,90 @@
+import { AfterViewInit, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { EChartsOption } from 'echarts';
+import { Charts, InvHistogramData } from 'src/app/types/charts';
+
+@Component({
+  selector: 'app-inv-histogram',
+  templateUrl: './inv-histogram.component.html',
+  styleUrls: ['./inv-histogram.component.scss']
+})
+export class InvHistogramComponent extends Charts implements AfterViewInit, OnChanges {
+  @Input() data: InvHistogramData;
+  @Input() id: string;
+
+  ngAfterViewInit() {
+    this.updateChart();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    this.data = changes['data'].currentValue;
+    this.updateChart();
+  }
+
+  constructor() {
+    super();
+    this.id = "";
+    this.data = {
+      rows: [],
+      values: []
+    };
+  }
+
+  generateChartOption(): EChartsOption {
+    // const colors = [
+    //   "#759aa0",
+    //   "#dd6b66",
+    //   "#e69d87",
+    //   "#8dc1a9",
+    //   "#eedd78",
+    //   "#ea7e53",
+    //   "#73a373",
+    //   "#73b9bc",
+    //   "#7289ab",
+    //   "#91ca8c",
+    //   "#f49f42"
+    // ].reverse(); // Define your colors here
+
+    return {
+      tooltip: {
+        trigger: 'item'
+      },
+      visualMap: {
+        orient: 'horizontal',
+        left: 'center',
+        min: this.data.visualMap?.min,
+        max: this.data.visualMap?.max,
+        text: this.data.visualMap?.text,
+        // Map the score column to color
+        dimension: 0,
+        inRange: {
+          // color: ['#65B581', '#FFCE34', '#FD665F']
+          color: ['#D1C4E9', '#673AB7', '#311B92']
+        },
+        textStyle: {
+          color: '#fff'
+        }
+      },
+      series: [
+        {
+          data: this.data.values,
+          // data: this.data.values.map((value, index) => ({ value, itemStyle: { color: colors[index % colors.length] } })),
+          type: 'bar',
+          barWidth: '60%',
+        }
+      ],
+      xAxis: {
+        type: 'value',
+      },
+      yAxis: {
+        type: 'category',
+        data: this.data.rows,
+        axisLabel: {
+          fontWeight: 'bold',
+          fontSize: 14
+        }
+      }
+    };
+  }
+
+}
+

--- a/src/app/types/charts.ts
+++ b/src/app/types/charts.ts
@@ -118,3 +118,14 @@ export const EMPTY_SCATTER_CONFIG: ScatterConfig = {
   data: [],
   names: []
 };
+
+// Inv Histogram
+export type InvHistogramData = {
+  values: number[];
+  rows: string[];
+  visualMap?: {
+    min: number;
+    max: number;
+    text: [string, string];
+  }
+}


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Les graphes des langues et des utilisateurs de la soirée électorale sont désormais des bar charts orientés sur l'axe des y plutôt que des pie charts pour plus de lisibilité quand beaucoup de valeurs sont affichées.

### :tada: Quality of life
* La combinaison des languages est maintenant affichée à part dans le graphe illustrant les languages, plutôt qu'elles comptent de manière indépendante.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie