### PR TITLE
Ajout d'un mode spectateur aux constitutions

### DIFF
--- a/src/app/components/constitution-page/constitution.component.html
+++ b/src/app/components/constitution-page/constitution.component.html
@@ -22,7 +22,7 @@
 	</table>
 	<span class="remaining-time-text"> {{getRemainingTimeMsg()}} </span>
 	<hr>
-	<button mat-raised-button color="primary" [disabled]="!updateSongs()" (click)="openDialogManageSongs()">
+	<button mat-raised-button color="primary" [disabled]="!updateSongs() || !isInConstitution()" (click)="openDialogManageSongs()">
 		<mat-icon>apps</mat-icon> Gérer mes musiques
 	</button>
 	<button mat-raised-button color="primary" (click)="openDialogRandomSong()">
@@ -56,7 +56,7 @@
 							(click)="setCurrentSection(constitutionSection.SONG_LIST)">
 				<mat-icon>queue_music</mat-icon> Liste des Musiques
 			</button>
-			<button mat-button [ngClass]="isSectionActive(constitutionSection.VOTES) ? 'active' : ''" 
+			<button *ngIf="isInConstitution()" mat-button [ngClass]="isSectionActive(constitutionSection.VOTES) ? 'active' : ''" 
 							(click)="setCurrentSection(constitutionSection.VOTES)">
 				<mat-icon>how_to_vote</mat-icon> Zone Électorale
 			</button>

--- a/src/app/components/constitution-page/constitution.component.ts
+++ b/src/app/components/constitution-page/constitution.component.ts
@@ -251,6 +251,9 @@ export class ConstitutionComponent implements OnDestroy {
 			default:
 				return `Il reste ${diffDays} jours à la constitution.`;
 		}
+	}
 
+	isInConstitution(): boolean {
+		return this.constitution.users.includes(this.auth.uid);
 	}
 }

--- a/src/app/components/constitution-page/results/results-grade/results-grade.component.html
+++ b/src/app/components/constitution-page/results/results-grade/results-grade.component.html
@@ -46,7 +46,7 @@
 						(click)="setCurrentSection(gradeResultSection.FAVORITES)">
 						<mat-icon>favorite</mat-icon> Favoris
 					</button>
-					<button mat-button [ngClass]="isSectionActive(gradeResultSection.PROFIL) ? 'active' : ''"
+					<button mat-button *ngIf="isInConstitution()" [ngClass]="isSectionActive(gradeResultSection.PROFIL) ? 'active' : ''"
 						(click)="setCurrentSection(gradeResultSection.PROFIL)">
 						<mat-icon>account_box</mat-icon> Mon Profil
 					</button>

--- a/src/app/components/constitution-page/results/results-grade/results-grade.component.ts
+++ b/src/app/components/constitution-page/results/results-grade/results-grade.component.ts
@@ -113,4 +113,7 @@ export class ResultsGradeComponent implements OnDestroy {
     this.songResults.sort(compareScore);
   }
 
+  isInConstitution(): boolean {
+		return this.constitution.users.includes(this.auth.uid);
+	}
 }

--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -69,7 +69,7 @@
 					<mat-icon>play_circle_outline</mat-icon>
 				</button>
 				<button mat-button color="primary" (click)="toggleFavorite(song, auth)"
-					[disabled]="noMoreFavorites(song) || !canModifyFavorite()">
+					[disabled]="noMoreFavorites(song) || !canModifyFavorite() || !isInConstitution()">
 					<mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
 				</button>
 				<app-optionnal-song-infos-button class="favorite-button" [song]="song" [isButtonRaised]="false">
@@ -96,7 +96,7 @@
 		<tr *ngFor="let song of getSongs()">
 			<td>
 				<button mat-button color="primary" (click)="toggleFavorite(song, auth)"
-					[disabled]="noMoreFavorites(song) || !canModifyFavorite()">
+					[disabled]="noMoreFavorites(song) || !canModifyFavorite() || !isInConstitution()">
 					<mat-icon *ngIf="isAFavorite(song); else normalSong" class="favorite">favorite</mat-icon>
 				</button>
 			</td>

--- a/src/app/components/constitution-page/song-list/song-list.component.ts
+++ b/src/app/components/constitution-page/song-list/song-list.component.ts
@@ -170,4 +170,8 @@ export class SongListComponent extends YatgaUserFavorites {
 		const status = !this.selectedUsers.includes(uid) ? "Cacher" : "Afficher";
 		return `${status} ${displayName}`;
 	}
+
+	isInConstitution(): boolean {
+		return this.constitution.users.includes(this.auth.uid);
+	}
 }

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.html
@@ -5,7 +5,7 @@
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
   <button mat-raised-button color="primary" class="favorite-button" (click)="toggleFavorite(currentSong, auth)"
-    [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite()">
+    [disabled]="noMoreFavorites(currentSong) || !canModifyFavorite() || !isInConstitution()">
     <mat-icon *ngIf="isAFavorite(currentSong); else normalSong" class="favorite">favorite</mat-icon>
   </button>
   <app-optionnal-song-infos-button class="favorite-button" [song]="currentSong"> </app-optionnal-song-infos-button>

--- a/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
+++ b/src/app/components/constitution-page/song-list/song-navigator/song-navigator.component.ts
@@ -84,4 +84,8 @@ export class SongNavigatorComponent extends YatgaUserFavorites implements OnDest
 	closeWindow(): void {
 		this.dialogRef.close();
 	}
+	
+	isInConstitution(): boolean {
+		return this.constitution.users.includes(this.auth.uid);
+	}
 }

--- a/src/app/components/current-constitution-page/current-constitution-page.component.html
+++ b/src/app/components/current-constitution-page/current-constitution-page.component.html
@@ -13,9 +13,9 @@
 					<th> Partie </th>
 					<th> Nom </th>
 					<th> Président </th>
-					<th> Youtube Playlist </th>
 					<th> Utilisateurs </th>	
-					<th> Statut </th>
+					<th></th>
+					<th></th>
 				</tr>
 				<tr *ngFor="let displayData of getConstitutions(false)">
 					<td>
@@ -31,21 +31,21 @@
 					<td> {{displayData.constitution.name}}</td>
 					<td> {{displayData.owner.displayName}} </td>
 					<td>
-						<div *ngIf="displayData.constitution.playlistLink !== ''">
-							<a target="_blank" href="{{displayData.constitution.playlistLink}}">
-								<mat-icon>library_music</mat-icon>
-							</a>
-						</div>
-						<div *ngIf="displayData.constitution.playlistLink === ''"> Pas de lien Youtube Playlist disponible
-						</div>
-					</td>
-					<td>
 						{{ displayData.constitution.users.length}} / {{ displayData.constitution.maxUserCount}}
 					</td>
 					<td [ngSwitch]="getStatus(displayData.constitution)">
-						<button mat-raised-button color="primary" *ngSwitchCase="'JOINED'" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">Voir</button>
-						<button mat-raised-button color="primary" *ngSwitchCase="'JOINABLE'" (click)="joinConstitution(displayData)" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">Rejoindre</button>
+						<button mat-raised-button color="primary" *ngSwitchCase="'JOINED'" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">
+							<mat-icon>chevron_right</mat-icon> Participer
+						</button>
+						<button mat-raised-button color="primary" *ngSwitchCase="'JOINABLE'" (click)="joinConstitution(displayData)" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">
+							<mat-icon>chevron_right</mat-icon> Rejoindre
+						</button>
 						<span *ngSwitchCase="'FULL'">Complet</span>
+					</td>
+					<td>
+						<button mat-raised-button color="primary" (click)="seeConstitution()" [disabled]="isInConstitution(displayData.constitution)" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">
+							<mat-icon>remove_red_eye</mat-icon> Consulter
+						</button>
 					</td>
 				</tr>
 			</table>
@@ -65,7 +65,7 @@
 					<th> Président </th>
 					<th> Youtube Playlist </th>
 					<th> Utilisateurs </th>	
-					<th> Statut </th>
+					<th> </th>
 				</tr>
 				<tr *ngFor="let displayData of getConstitutions(true)">
 					<td>
@@ -93,9 +93,9 @@
 						{{ displayData.constitution.users.length}} / {{ displayData.constitution.maxUserCount}}
 					</td>
 					<td [ngSwitch]="getStatus(displayData.constitution)">
-						<button mat-raised-button color="primary" *ngSwitchCase="'JOINED'" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">Voir</button>
-						<button mat-raised-button color="primary" *ngSwitchCase="'JOINABLE'" (click)="joinConstitution(displayData)" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">Rejoindre</button>
-						<span *ngSwitchCase="'FULL'">Complet</span>
+						<button mat-raised-button color="primary" [routerLink]="['/constitution/', displayData.constitution.id, 'songList']">
+							<mat-icon>remove_red_eye</mat-icon> Consulter
+						</button>
 					</td>
 				</tr>
 			</table>

--- a/src/app/components/current-constitution-page/current-constitution-page.component.ts
+++ b/src/app/components/current-constitution-page/current-constitution-page.component.ts
@@ -7,6 +7,7 @@ import {
 	UsrReqGet, UsrReqUnsubscribe, UsrResUpdate
 } from 'chelys';
 import { AuthService } from 'src/app/services/auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 const OWNER_INDEX = 0;
 
@@ -40,7 +41,7 @@ export class CurrentConstitutionPageComponent implements OnDestroy {
 
 	public constitutions: Map<string, DisplayData>;
 
-	constructor(private auth: AuthService) {
+	constructor(private auth: AuthService, private _snackBar: MatSnackBar) {
 		this.constitutions = new Map();
 		this.auth.pushAuthFunction(this.onConnect, this);
 		this.auth.pushEventHandler(this.handleEvents, this);
@@ -109,7 +110,21 @@ export class CurrentConstitutionPageComponent implements OnDestroy {
 		return ConstitutionStatus.FULL;
 	}
 
-	joinConstitution(data: DisplayData) {
+	joinConstitution(data: DisplayData): void {
 		this.auth.ws.send(createMessage<CstReqJoin>(EventType.CST_join, { id: data.constitution.id }));
+	}
+
+	seeConstitution(): void {
+		this.openSnackBar("Vous êtes en mode consultation seulement", 'OK');
+	}
+
+	isInConstitution(cst: Constitution): boolean {
+		return cst.users.includes(this.auth.uid);
+	}
+
+	openSnackBar(message: string, action: string) {
+		this._snackBar.open(message, action, {
+			horizontalPosition: 'right'
+		});
 	}
 }


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :rocket: Nouveauté
* Il est désormais possible de consulter les chansons et les résultats d'une constitution publique sans y être membre.

### :tada: Quality of life
* Retrait de la colonne "Youtube Playlist" de la table présentant les constitutions en cours.

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie