### PR TITLE
Ajout d'un tooltip pour les titres des musiques

### DIFF
--- a/src/app/components/constitution-page/song-list/song-list.component.html
+++ b/src/app/components/constitution-page/song-list/song-list.component.html
@@ -39,7 +39,7 @@
 			<mat-card-header>
 				<img mat-card-avatar src="{{getUser(song.user).photoURL}}"
 					matTooltip="{{getUser(song.user).displayName}}">
-				<mat-card-title class="card-text text-overflowable"> {{songPropertyManager.getTitle(song)}}
+				<mat-card-title class="card-text text-overflowable" matTooltip="{{songPropertyManager.getTitle(song)}}"> {{songPropertyManager.getTitle(song)}}
 				</mat-card-title>
 				<mat-card-subtitle class="card-text text-overflowable" matTooltip="{{songPropertyManager.getSubTitle(song)}}"> <i> {{songPropertyManager.getSubTitle(song)}}
 					</i> </mat-card-subtitle>

--- a/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
+++ b/src/app/components/constitution-page/votes/votes-grade/votes-grade.component.html
@@ -79,7 +79,7 @@
       <mat-card *ngFor="let song of getSongsToVote()" class="card-r">
         <mat-card-header>
           <img mat-card-avatar src="{{getUser(song.user).photoURL}}" matTooltip="{{getUser(song.user).displayName}}">
-          <mat-card-title class="card-text text-overflowable"> {{songPropertyManager.getTitle(song)}} </mat-card-title>
+          <mat-card-title class="card-text text-overflowable" matTooltip="{{songPropertyManager.getTitle(song)}}"> {{songPropertyManager.getTitle(song)}} </mat-card-title>
           <mat-card-subtitle class="card-text text-overflowable" matTooltip="{{songPropertyManager.getSubTitle(song)}}"> <i> {{songPropertyManager.getSubTitle(song)}} </i> </mat-card-subtitle>
         </mat-card-header>
         <hr>


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* Ajout d'un tooltip sur le titre des musiques affichées via les cartes afin de pouvoir lire le titre complet, même si celui-ci dépasse de la carte.

<img width="440" alt="Capture d’écran, le 2025-03-22 à 08 41 44" src="https://github.com/user-attachments/assets/4c7d9695-8765-4aa5-934f-49e5fe9ae85d" />

## Checklist

- [ ] Titre
- [ ] Label
- [ ] Catégorie